### PR TITLE
Display member tags in the github popover

### DIFF
--- a/src/github/dom-helpers.js
+++ b/src/github/dom-helpers.js
@@ -55,3 +55,24 @@ const createOrbitMetric = (label, value, iconPath) => {
 
   return orbitMetricContainer;
 };
+
+export const createTagList = (tagList) => {
+  const detailsMenuTagList = window.document.createElement("div");
+  detailsMenuTagList.setAttribute("role", "menuitem");
+  detailsMenuTagList.classList.add(
+    "dropdown-item",
+    "dropdown-item-orbit",
+    "no-hover",
+    "orbit-tags-container",
+    "d-flex"
+  );
+
+  tagList.forEach((tag) => {
+    let tagText = window.document.createElement("span");
+    tagText.classList.add("orbit-tag");
+    tagText.innerHTML = `${tag}`;
+    detailsMenuTagList.appendChild(tagText);
+  });
+
+  return detailsMenuTagList;
+};

--- a/src/github/orbit-action.css
+++ b/src/github/orbit-action.css
@@ -46,3 +46,19 @@ details[open] > .timeline-comment-action.orbit-icon-container {
   top: 1px;
   margin-right: 5px;
 }
+
+.orbit-tags-container {
+  flex-wrap: wrap;
+  max-width: 250px;
+}
+
+.orbit-tag {
+  background-color: #ebe7fe;
+  margin: 3px 4px 3px 0px;
+  border-radius: 4px;
+  display: inline-block;
+  padding: 2px 8px 3px;
+  color: #5b41cf;
+  font-family: Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+  font-size: 12px;
+}

--- a/src/github/orbit-action.js
+++ b/src/github/orbit-action.js
@@ -1,5 +1,9 @@
 import { getThreshold, orbitAPI } from "./orbit-helpers";
-import { createDropdownItem, createOrbitMetrics } from "./dom-helpers";
+import {
+  createDropdownItem,
+  createOrbitMetrics,
+  createTagList,
+} from "./dom-helpers";
 import { ORBIT_API_ROOT_URL } from "../constants";
 
 /**
@@ -42,6 +46,7 @@ export async function createOrbitDetailsElement(
     $orbit_level,
     $reach,
     $love,
+    $tag_list,
     $success,
     $slug,
     $detailsMenuElement,
@@ -144,7 +149,7 @@ export async function createOrbitDetailsElement(
        * github user info) at the same time, resulting in better performance.
        */
       const [
-        { status, slug, orbit_level, reach, love },
+        { status, slug, orbit_level, reach, love, tag_list },
         { contributions_total, success: successGithubUserRequest },
       ] = await Promise.all([
         orbitAPI.getMemberContributions(ORBIT_CREDENTIALS, gitHubUsername),
@@ -160,6 +165,7 @@ export async function createOrbitDetailsElement(
         $orbit_level = orbit_level;
         $reach = reach;
         $love = love;
+        $tag_list = tag_list;
       }
       $success = successGithubUserRequest;
       $contributions_total = contributions_total;
@@ -246,6 +252,16 @@ export async function createOrbitDetailsElement(
     );
 
     $detailsMenuElement.appendChild(detailsMenuOrbitMetrics);
+
+    /**
+     * <div>Tag list</div>
+     */
+
+    if ($tag_list.length > 0) {
+      const detailsMenuTagList = createTagList($tag_list);
+
+      $detailsMenuElement.appendChild(detailsMenuTagList);
+    }
 
     /**
      * <span class="dropdown-divider"></span>

--- a/src/github/orbit-action.test.js
+++ b/src/github/orbit-action.test.js
@@ -24,6 +24,7 @@ beforeEach(async () => {
             orbit_level: 1,
             reach: 5,
             love: 9,
+            tag_list: ["Speaker"],
           },
         },
       })
@@ -140,6 +141,7 @@ test("createOrbitDetailsElement should display Orbit info if the github user is 
     new MouseEvent("mouseover")
   );
   await waitFor(() => {
+    expect(getByText(orbitDetailsElement, "Speaker"));
     expect(getByText(orbitDetailsElement, "Contributed 10+ times on GitHub"));
     expect(getByText(orbitDetailsElement, "See phacks’s profile on Orbit"));
   });

--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -92,6 +92,7 @@ export const orbitAPI = {
         orbit_level: member.attributes.orbit_level,
         reach: member.attributes.reach,
         love: member.attributes.love,
+        tag_list: member.attributes.tag_list,
         contributions_total: member.attributes.contributions_total,
       };
     } catch (err) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2587348/101368401-67607280-38a7-11eb-9234-cb0840769008.png)

Following a user feedback:

> I’m using the Chrome Extension for GitHub and I thought it would be handy to see the tags that are applied to a user in Orbit in the hover-over (along with their number of contributions)