### PR TITLE
Fixed an issue due to love being a string

### DIFF
--- a/src/github/dom-helpers.js
+++ b/src/github/dom-helpers.js
@@ -33,7 +33,7 @@ export const createOrbitMetrics = (orbitLevel, reach, love) => {
 
   const loveMetricContainer = createOrbitMetric(
     "Love",
-    love.toFixed(1),
+    parseFloat(love).toFixed(1),
     "icons/icon-love.png"
   );
   detailsMenuOrbitMetrics.appendChild(loveMetricContainer);


### PR DESCRIPTION
A change in the `love` response format (from float to string) caused the widget to not display properly.