### PR TITLE
Add support for GH Discussions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,8 @@
       "run_at": "document_start",
       "matches": [
         "https://github.com/*/*/pull/*",
-        "https://github.com/*/*/issues/*"
+        "https://github.com/*/*/issues/*",
+        "https://github.com/*/*/discussions/*"
       ],
       "css": ["src/github/orbit-action.css"],
       "js": ["src/github/background.js"]

--- a/manifest.json
+++ b/manifest.json
@@ -11,9 +11,10 @@
     {
       "run_at": "document_start",
       "matches": [
+        "https://github.com/*/*/pulls*",
         "https://github.com/*/*/pull/*",
-        "https://github.com/*/*/issues/*",
-        "https://github.com/*/*/discussions/*"
+        "https://github.com/*/*/issues*",
+        "https://github.com/*/*/discussions*"
       ],
       "css": ["src/github/orbit-action.css"],
       "js": ["src/github/background.js"]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.0",
     "chrome-extension-async": "^3.4.1",
-    "github-injection": "^1.0.1",
+    "github-injection": "^1.1.0",
     "tailwindcss": "^1.4.6"
   }
 }

--- a/src/github/background.js
+++ b/src/github/background.js
@@ -3,6 +3,7 @@ import gitHubInjection from "github-injection";
 
 import { getOrbitCredentials, isRepoInOrbitWorkspace } from "./orbit-helpers";
 import { createOrbitDetailsElement } from "./orbit-action";
+import { getPageType } from "./page-helpers";
 
 document.addEventListener("DOMContentLoaded", async () => {
   /**
@@ -16,6 +17,12 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const isRepoInWorkspace = await isRepoInOrbitWorkspace();
 
+  const pageType = getPageType();
+
+  if (pageType === null) {
+    return;
+  }
+
   /**
    * GitHub uses pjax (https://github.com/MoOx/pjax) to speed its
    * navigation, a bit like Turbolinks does.
@@ -28,14 +35,15 @@ document.addEventListener("DOMContentLoaded", async () => {
      * Find all the “comment headers” on the page (this extension is only
      * active on /pull/* and /issues/* URLs).
      */
-    const commentHeaders = window.document.getElementsByClassName(
-      "timeline-comment-header"
-    );
+    const comments = window.document.getElementsByClassName("timeline-comment");
     /**
      * For each comment header, create and add the Orbit action to
      * the “comment action” section of the DOM.
      */
-    for (const commentHeader of commentHeaders) {
+    for (const comment of comments) {
+      if (!comment.querySelector(".timeline-comment-actions")) {
+        break;
+      }
       /**
        * GitHub pjax sometimes triggers the `githubInjection` multiple times on a single page,
        * which resulted in multiple Orbit icons being visible side by side. I was able to reproduce this
@@ -43,25 +51,40 @@ document.addEventListener("DOMContentLoaded", async () => {
        *
        * We thus check if Orbit is already instanciated; if that’s the case, we bail out.
        */
-      let isOrbitActionElementAlreadyInstantiated = commentHeader.querySelector(
+      let isOrbitActionElementAlreadyInstantiated = comment.querySelector(
         ".orbit-icon-container"
       );
       if (isOrbitActionElementAlreadyInstantiated) {
         break;
       }
 
-      const commentActionsElement = commentHeader.querySelector(
+      const commentActionsElement = comment.querySelector(
         ".timeline-comment-actions"
       );
-      const gitHubUsername = commentHeader.querySelector(".author").innerText;
+
+      // For discussions, some messages do not have the .author class, so we target the span right close to the avatar img.
+      // For issues + PRs (and some discussion messages), the author element has the .author classs.
+      const authorElement =
+        comment.querySelector('a > img[class~="avatar"] + div > span') ||
+        comment.querySelector(".author");
+
+      const gitHubUsername = authorElement.innerText;
+
+      const relativeTimeElement = comment.querySelector("relative-time");
+
+      if (!relativeTimeElement) {
+        break;
+      }
+
       const commentUrl =
         window.location.href +
-        commentHeader
-          .querySelector("relative-time")
-          .parentElement.getAttribute("href");
-      const commentPublishedAt = commentHeader
-        .querySelector("relative-time")
-        .getAttribute("datetime");
+        relativeTimeElement.parentElement.getAttribute("href");
+
+      const commentPublishedAt = relativeTimeElement.getAttribute("datetime");
+
+      if (!commentPublishedAt) {
+        break;
+      }
 
       const orbitActionElement = await createOrbitDetailsElement(
         ORBIT_CREDENTIALS,
@@ -70,10 +93,19 @@ document.addEventListener("DOMContentLoaded", async () => {
         commentUrl,
         commentPublishedAt
       );
-      commentActionsElement.insertBefore(
-        orbitActionElement,
-        commentActionsElement.firstChild
-      );
+
+      // The element must be inserted at different places if it's in a Discussions message
+      if (pageType === "ISSUE" || pageType === "PULL_REQUEST") {
+        commentActionsElement.insertBefore(
+          orbitActionElement,
+          commentActionsElement.children[0]
+        );
+      } else {
+        commentActionsElement.children[0].insertBefore(
+          orbitActionElement,
+          commentActionsElement.children[0].children[0]
+        );
+      }
     }
   });
 });

--- a/src/github/background.js
+++ b/src/github/background.js
@@ -17,12 +17,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const isRepoInWorkspace = await isRepoInOrbitWorkspace();
 
-  const pageType = getPageType();
-
-  if (pageType === null) {
-    return;
-  }
-
   /**
    * GitHub uses pjax (https://github.com/MoOx/pjax) to speed its
    * navigation, a bit like Turbolinks does.
@@ -31,6 +25,12 @@ document.addEventListener("DOMContentLoaded", async () => {
    * to make the extension work even after a page navigation.
    */
   gitHubInjection(async () => {
+    const pageType = getPageType();
+
+    if (pageType === null) {
+      return;
+    }
+
     /**
      * Find all the “comment headers” on the page (this extension is only
      * active on /pull/* and /issues/* URLs).

--- a/src/github/dom-helpers.js
+++ b/src/github/dom-helpers.js
@@ -33,7 +33,7 @@ export const createOrbitMetrics = (orbitLevel, reach, love) => {
 
   const loveMetricContainer = createOrbitMetric(
     "Love",
-    parseFloat(love).toFixed(1),
+    love === null ? "N/A" : parseFloat(love).toFixed(1),
     "icons/icon-love.png"
   );
   detailsMenuOrbitMetrics.appendChild(loveMetricContainer);

--- a/src/github/orbit-action.css
+++ b/src/github/orbit-action.css
@@ -37,6 +37,8 @@ details[open] > .timeline-comment-action.orbit-icon-container {
 .orbit-metric-container {
   align-items: center;
   display: flex;
+  padding-left: 3px;
+  padding-right: 3px;
 }
 
 .orbit-metrics-container img {
@@ -44,7 +46,7 @@ details[open] > .timeline-comment-action.orbit-icon-container {
   height: 16px;
   position: relative;
   top: 1px;
-  margin-right: 5px;
+  margin-right: 3px;
 }
 
 .orbit-tags-container {

--- a/src/github/orbit-action.js
+++ b/src/github/orbit-action.js
@@ -170,18 +170,20 @@ export async function createOrbitDetailsElement(
       $success = successGithubUserRequest;
       $contributions_total = contributions_total;
       if (isRepoInWorkspace) {
-        const {
-          success,
-          contributions_on_this_repo_total,
-        } = await orbitAPI.getMemberActivitiesOnThisRepo(
-          ORBIT_CREDENTIALS,
-          $slug
-        );
+        const { success, contributions_on_this_repo_total } =
+          await orbitAPI.getMemberActivitiesOnThisRepo(
+            ORBIT_CREDENTIALS,
+            $slug
+          );
 
         $contributions_on_this_repo_total = contributions_on_this_repo_total;
         $success = success;
       }
       $hasLoaded = true;
+
+      if ($orbit_level === null) {
+        $orbit_level = "None";
+      }
 
       /**
        * Clean up the event listener and display the actual content.

--- a/src/github/page-helpers.js
+++ b/src/github/page-helpers.js
@@ -1,0 +1,19 @@
+export const getPageType = () => {
+  const issuePageRegex = /.*\/.*\/issues?\/.*/;
+  const pullRequestPageRegex = /.*\/.*\/pulls?\/.*/;
+  const discussionPageRegex = /.*\/.*\/discussions?\/.*/;
+
+  const currentPath = window.location.pathname;
+
+  if (currentPath.match(issuePageRegex)) {
+    return "ISSUE";
+  }
+  if (currentPath.match(pullRequestPageRegex)) {
+    return "PULL_REQUEST";
+  }
+  if (currentPath.match(discussionPageRegex)) {
+    return "DISCUSSION";
+  }
+
+  return;
+};

--- a/src/github/page-helpers.test.js
+++ b/src/github/page-helpers.test.js
@@ -1,0 +1,45 @@
+import { getPageType } from "./page-helpers";
+
+beforeEach(() => {
+  global.window = Object.create(window);
+});
+
+afterEach(() => {
+  global.window = null;
+});
+
+test("getPageType should return 'ISSUE' for issues pages", () => {
+  const pathname = "/hzoo/contributors-on-github/issues/34";
+  Object.defineProperty(window, "location", {
+    value: {
+      pathname,
+    },
+    writable: true,
+  });
+
+  expect(getPageType()).toBe("ISSUE");
+});
+
+test("getPageType should return 'PULL_REQUEST' for pull request pages", () => {
+  const pathname = "/orbit-love/orbit-app/pull/2459";
+  Object.defineProperty(window, "location", {
+    value: {
+      pathname,
+    },
+    writable: true,
+  });
+
+  expect(getPageType()).toBe("PULL_REQUEST");
+});
+
+test("getPageType should return 'DISCUSSIONS' for discussions pages", () => {
+  const pathname = "/stimulusreflex/stimulus_reflex/discussions/497";
+  Object.defineProperty(window, "location", {
+    value: {
+      pathname,
+    },
+    writable: true,
+  });
+
+  expect(getPageType()).toBe("DISCUSSION");
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3308,10 +3308,10 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-github-injection@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/github-injection/-/github-injection-1.0.1.tgz#fad4bee67b988993c527556101a87138245ed0dc"
-  integrity sha1-+tS+5nuYiZPFJ1VhAahxOCRe0Nw=
+github-injection@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/github-injection/-/github-injection-1.1.0.tgz#3804bcb65cfdc302df49c8a5152bd43ac00aa95f"
+  integrity sha512-XoypofQSVTLaMlMlcp52Y6v+E58FhonB2iK2FzlBPRP/XxrnfJa4rEDgiD5phiki2jeW5oaP+tcwplbiiA3rMg==
 
 glob-parent@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Closes #16 (at last!)

This PR adds support for the Orbit contextual widget inside GitHub Discussions:

<img width="935" alt="CleanShot 2022-07-06 at 16 19 23@2x" src="https://user-images.githubusercontent.com/2587348/177572255-43cf7d19-3b8b-49c0-8327-0e262cfa32c7.png">

It doesn’t require additional configuration, and should work out of the box when updated in the Chrome Web Store.

## How to test this PR

Follow the [local installation guide](https://github.com/orbit-love/orbit-browser-extension#local-installation), then:

- Check out the branch locally
- Run `yarn start`
- Reload the extension, so that you have the new code running in Chrome
- Visit some Discussions, for example in the [StimulusReflex repo](https://github.com/stimulusreflex/stimulus_reflex/discussions), or the [Nuxt.JS one](https://github.com/nuxt/nuxt.js/discussions), or the [Remix one](https://github.com/remix-run/remix/discussions)…