### PR TITLE
Fix Incorrect Repository Contribution Count

### DIFF
--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -115,7 +115,7 @@ export const orbitAPI = {
     const repositoryFullName = _getRepositoryFullName();
     try {
       const response = await fetch(
-        `${ORBIT_API_ROOT_URL}/${ORBIT_CREDENTIALS.WORKSPACE}/activities?member_id=${member}&properties=github_repository:${repositoryFullName}&api_key=${ORBIT_CREDENTIALS.API_TOKEN}`,
+        `${ORBIT_API_ROOT_URL}/${ORBIT_CREDENTIALS.WORKSPACE}/activities?member_id=${member}&properties=github_repository:${repositoryFullName}&items=100&api_key=${ORBIT_CREDENTIALS.API_TOKEN}`,
         {
           headers: {
             ...ORBIT_HEADERS,
@@ -128,16 +128,11 @@ export const orbitAPI = {
           status: response.status,
         };
       }
-      const { data, included } = await response.json();
-      const filteredActivities = _filterActivitiesByRepo(
-        data,
-        included,
-        repositoryFullName
-      );
+      const { data } = await response.json();
       return {
         success: true,
         status: response.status,
-        contributions_on_this_repo_total: filteredActivities.length,
+        contributions_on_this_repo_total: data.length,
       };
     } catch (err) {
       console.error(err);
@@ -277,40 +272,6 @@ export const orbitAPI = {
     }
   },
 };
-
-/**
- * Filters all activities from a member and returns only those
- * that are attached to the given repositoryFullName.
- *
- * @param {*} activities as returned by Orbit API
- * @param {*} included as returned by Orbit API
- * @param {*} repositoryFullName the full name of the current repository
- *
- * @returns a filtered list of activities.
- */
-export function _filterActivitiesByRepo(
-  activities,
-  included,
-  repositoryFullName
-) {
-  /**
-   * First, find out the internal repositoryId by filtering the `included`
-   * data by type === repository and full_name === repositoryFullName
-   */
-  const filterIncludedByTypeRepository = (data) => data.type === "repository";
-  const filterIncludedByRepositoryFullName = (data) =>
-    data.attributes.full_name === repositoryFullName;
-  const repositoryId = included
-    .filter(filterIncludedByTypeRepository)
-    .filter(filterIncludedByRepositoryFullName)[0]?.id;
-
-  /**
-   * Then filter the activities by that repositoryId
-   */
-  return activities.filter(
-    (data) => data.relationships.repository?.data?.id === repositoryId
-  );
-}
 
 /**
  * Returns the current repository full name based on the current URL.

--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -115,7 +115,7 @@ export const orbitAPI = {
     const repositoryFullName = _getRepositoryFullName();
     try {
       const response = await fetch(
-        `${ORBIT_API_ROOT_URL}/${ORBIT_CREDENTIALS.WORKSPACE}/activities?member_id=${member}&properties=github_repository:${repositoryFullName}&items=100&api_key=${ORBIT_CREDENTIALS.API_TOKEN}`,
+        `${ORBIT_API_ROOT_URL}/${ORBIT_CREDENTIALS.WORKSPACE}/activities?member_id=${member}&properties=github_repository:${repositoryFullName}&items=25&api_key=${ORBIT_CREDENTIALS.API_TOKEN}`,
         {
           headers: {
             ...ORBIT_HEADERS,

--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -115,11 +115,7 @@ export const orbitAPI = {
     const repositoryFullName = _getRepositoryFullName();
     try {
       const response = await fetch(
-        `${ORBIT_API_ROOT_URL}/${
-          ORBIT_CREDENTIALS.WORKSPACE
-        }/activities?member_id=${member}&properties=${encodeURIComponent(
-          `github_repository:${repositoryFullName}`
-        )}&api_key=${ORBIT_CREDENTIALS.API_TOKEN}`,
+        `${ORBIT_API_ROOT_URL}/${ORBIT_CREDENTIALS.WORKSPACE}/activities?member_id=${member}&properties=github_repository:${repositoryFullName}&api_key=${ORBIT_CREDENTIALS.API_TOKEN}`,
         {
           headers: {
             ...ORBIT_HEADERS,

--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -93,7 +93,7 @@ export const orbitAPI = {
         reach: member.attributes.reach,
         love: member.attributes.love,
         tag_list: member.attributes.tag_list,
-        contributions_total: member.attributes.contributions_total
+        contributions_total: member.attributes.contributions_total,
       };
     } catch (err) {
       console.error(err);
@@ -112,9 +112,14 @@ export const orbitAPI = {
    * @returns {is_a_member, contributions_on_this_repo_total}
    */
   async getMemberActivitiesOnThisRepo(ORBIT_CREDENTIALS, member) {
+    const repositoryFullName = _getRepositoryFullName();
     try {
       const response = await fetch(
-        `${ORBIT_API_ROOT_URL}/${ORBIT_CREDENTIALS.WORKSPACE}/members/${member}/activities?api_key=${ORBIT_CREDENTIALS.API_TOKEN}`,
+        `${ORBIT_API_ROOT_URL}/${
+          ORBIT_CREDENTIALS.WORKSPACE
+        }/activities?member_id=${member}&properties=${encodeURIComponent(
+          `github_repository:${repositoryFullName}`
+        )}&api_key=${ORBIT_CREDENTIALS.API_TOKEN}`,
         {
           headers: {
             ...ORBIT_HEADERS,
@@ -128,7 +133,6 @@ export const orbitAPI = {
         };
       }
       const { data, included } = await response.json();
-      const repositoryFullName = _getRepositoryFullName();
       const filteredActivities = _filterActivitiesByRepo(
         data,
         included,
@@ -249,7 +253,7 @@ export const orbitAPI = {
           body: JSON.stringify({
             activity_type: "content",
             url: commentUrl,
-            occurred_at: commentPublishedAt
+            occurred_at: commentPublishedAt,
           }),
           headers: {
             "Content-Type": "application/json",

--- a/src/github/orbit-helpers.test.js
+++ b/src/github/orbit-helpers.test.js
@@ -1,9 +1,4 @@
-import testData from "./testData/activities.json";
-
-import {
-  _getRepositoryFullName,
-  _filterActivitiesByRepo,
-} from "./orbit-helpers";
+import { _getRepositoryFullName } from "./orbit-helpers";
 
 test("_getRepositoryFullName should return the full name of the repository based on window.location.pathname", () => {
   global.window = Object.create(window);
@@ -14,23 +9,4 @@ test("_getRepositoryFullName should return the full name of the repository based
     },
   });
   expect(_getRepositoryFullName()).toBe("hzoo/contributors-on-github");
-});
-
-test("_filterActivitiesByRepo should filter activities by repository", () => {
-  const activities = testData.data;
-  const included = testData.included;
-  const repositoryFullName = "theodo/falco";
-
-  expect(activities.length).toBe(3);
-  const filteredActivities = _filterActivitiesByRepo(
-    activities,
-    included,
-    repositoryFullName
-  );
-  expect(filteredActivities.length).toBe(2);
-  expect(
-    filteredActivities.map(
-      (activity) => activity.relationships.repository.data.id
-    )
-  ).toEqual(["210", "210"]);
 });


### PR DESCRIPTION
Historical behaviour:

1. Fetch paginated list of members github activity, default limit of 25
2. Filter these to the current repo
3. Display number of contributions for the current repo, capped at 20

Therefore, if a member had activity spread across multiple repositories (ie

```
Member does 10 activities for repo 1
Member does 15 activities for repo 2
Member does 5 more activities for repo 1
```

then we could miss some. In the above example, the member would be treated as only performing 10 activities on repo 1, because we wouldn't return the additional 5 in this request.

New behaviour:

1. Fetch paginated list of members github activity for just this repo, limited to 25
2. Display number of contributions for the current repo, capped at 20

By filtering the repos on the server, we don't need to worry about filtering them manually in the extension

---

Closes https://github.com/orbit-love/orbit-browser-extension/issues/25

**Relies on CORs change made by https://github.com/orbit-love/orbit-app/pull/4026; ensure that is merged first**