### PR TITLE
Fix: Support storing large numbers of repositories in chrome cache

### DIFF
--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -330,6 +330,16 @@ export function _getRepositoryFullName() {
 export async function _fetchRepositories() {
   const { repository_keys } = await chrome.storage.sync.get("repository_keys");
 
+  // Backwards compatibility - if we do not have repository keys,
+  //  default to how we used to store them
+  if (repository_keys === undefined) {
+    const { repositories } = await chrome.storage.sync.get({
+      repositories: "",
+    });
+
+    return repositories;
+  }
+
   // Map the repositories to an array of "fetch from storage" promises
   const promises = repository_keys.map((key) => chrome.storage.sync.get(key));
 

--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -333,9 +333,7 @@ export async function _fetchRepositories() {
   // Backwards compatibility - if we do not have repository keys,
   //  default to how we used to store them
   if (repository_keys === undefined) {
-    const { repositories } = await chrome.storage.sync.get({
-      repositories: "",
-    });
+    const { repositories } = await chrome.storage.sync.get("repositories");
 
     return repositories;
   }

--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -16,9 +16,7 @@ export async function getOrbitCredentials() {
 }
 
 export async function isRepoInOrbitWorkspace() {
-  const { repositories } = await chrome.storage.sync.get({
-    repositories: "",
-  });
+  const repositories = await _fetchRepositories();
   return repositories.includes(_getRepositoryFullName());
 }
 
@@ -93,7 +91,7 @@ export const orbitAPI = {
         reach: member.attributes.reach,
         love: member.attributes.love,
         tag_list: member.attributes.tag_list,
-        contributions_total: member.attributes.contributions_total
+        contributions_total: member.attributes.contributions_total,
       };
     } catch (err) {
       console.error(err);
@@ -249,7 +247,7 @@ export const orbitAPI = {
           body: JSON.stringify({
             activity_type: "content",
             url: commentUrl,
-            occurred_at: commentPublishedAt
+            occurred_at: commentPublishedAt,
           }),
           headers: {
             "Content-Type": "application/json",
@@ -322,4 +320,29 @@ export function _getRepositoryFullName() {
   return `${window.location.pathname.split("/")[1]}/${
     window.location.pathname.split("/")[2]
   }`;
+}
+
+/**
+ * Fetches chunked repositories from chrome storage
+ *
+ * @returns Array<String> a 1d array of all repsoitory names, ie ["repo-1", "repo-2"]
+ */
+export async function _fetchRepositories() {
+  const { repository_keys } = await chrome.storage.sync.get("repository_keys");
+
+  // Map the repositories to an array of "fetch from storage" promises
+  const promises = repository_keys.map((key) => chrome.storage.sync.get(key));
+
+  // Wait for all promises to resolve
+  // This returns repositories in the following structure:
+  // [
+  //  { sally:repositories:1: ["repo-1", "repo-2", ...] },
+  //  { sally:repositories:2: ["repo-101", "repo-102",...] },
+  // ]
+  const repositoryObjects = await Promise.all(promises);
+
+  // Reduce repositories to 1d array, disregarding the keys
+  return repositoryObjects
+    .flatMap((repository_object) => Object.values(repository_object))
+    .flat();
 }

--- a/src/github/orbit-helpers.test.js
+++ b/src/github/orbit-helpers.test.js
@@ -67,3 +67,33 @@ test("_fetchRepositories should collapse chunked repositories into a single arra
 
   global.chrome = originalChrome;
 });
+
+test("_fetchRepositories should support a single array", async () => {
+  const mockChromeStorage = {
+    storage: {
+      repositories: ["repo-1", "repo-2", "repo-3", "repo-4"],
+    },
+    get: function (key) {
+      const result = {};
+
+      result[key] = this.storage[key];
+
+      return result;
+    },
+  };
+
+  let originalChrome = global.chrome;
+
+  global.chrome = {
+    storage: {
+      sync: mockChromeStorage,
+    },
+  };
+
+  const repositories = await _fetchRepositories();
+
+  expect(repositories.length).toBe(4);
+  expect(repositories).toEqual(["repo-1", "repo-2", "repo-3", "repo-4"]);
+
+  global.chrome = originalChrome;
+});

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -37,7 +37,6 @@ window.orbit = () => ({
         const { data, included } = await response.json();
         workspaces = data;
         repositories = included.filter((item) => item.type === "repository");
-        console.log(repositories);
       } catch (err) {
         console.error(err);
       }
@@ -162,13 +161,6 @@ window.orbit = () => ({
     chrome.storage.sync.set(storageData, function () {
       that.saveStatus.success = true;
       that.saveStatus.message = "Saved successfully, you can close this page.";
-    });
-
-    // TESTING: Retrieving & logging the stored data
-    chrome.storage.sync.get("repository_keys", ({ repository_keys }) => {
-      chrome.storage.sync.get(repository_keys[0], (repositories) => {
-        console.log("Repositories", repositories);
-      });
     });
   },
 });

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -142,14 +142,15 @@ document.addEventListener("alpine:init", () => {
      */
     _buildStorageObject(token, workspaceSlug, repositories) {
       const storageObject = {};
+      const repository_keys = this._persistRepositories(
+        workspaceSlug,
+        repositories
+      );
 
       // Set common variables
       storageObject["token"] = token;
       storageObject["workspace"] = workspaceSlug;
-      storageObject["repository_keys"] = this._persistRepositories(
-        workspaceSlug,
-        repositories
-      );
+      storageObject["repository_keys"] = repository_keys;
 
       return storageObject;
     },

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -92,32 +92,49 @@ window.orbit = () => ({
     );
     return result;
   },
+  /**
+   * Break array of repositories into chunks of 100, and
+   * store them independently in Chrome storage
+   *
+   * @param {String} workspaceSlug the slug of the Orbit workspace, used to generate a key for the repositories
+   * @param {Array<String>} repositories the un-chunked array of repository names
+   *
+   * @returns Array<String> the addresses of the chunked repositories
+   */
   _persistRepositories(workspaceSlug, repositories) {
     // Addresses of the chunked repositories so we can retrieve them later
     let repository_keys = [];
+    let counter = 1;
 
-    // Used to number the chunked repository keys
-    let j = 1;
-
-    // Break repositories down into chunks of 100 &
-    // store them separately
-    // IE if there are 240 repositories, they will be saved as:
+    // If there are 240 repositories for workspace "sally", they will be saved as:
     //
     // sally:repositories:1 // Repositories 0-100
     // sally:repositories:2 // Repositories 101-200
     // sally:repositories:3 // Repositories 201-240
     while (repositories.length > 0) {
-      let key = `${workspaceSlug}:repositories:${j}`;
+      let key = `${workspaceSlug}:repositories:${counter}`;
 
       repository_keys.push(key);
       chrome.storage.sync.set({
         [key]: repositories.splice(0, 100),
       });
-      j++;
+      counter++;
     }
 
     return repository_keys;
   },
+  /**
+   * Build the object of data to persist, including:
+   * - token: the users API token
+   * - workspace: slug of the selected workspace
+   * - repository_keys: addresses of the chunked repositories
+   *
+   * @param {String} token the users API token
+   * @param {String} workspaceSlug the slug of the Orbit workspace, used to generate a key for the repositories
+   * @param {Array<String>} repositories the un-chunked array of repository names
+   *
+   * @returns {token, workspace, repository_keys}
+   */
   _buildStorageObject(token, workspaceSlug, repositories) {
     const storageObject = {};
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -37,6 +37,7 @@ window.orbit = () => ({
         const { data, included } = await response.json();
         workspaces = data;
         repositories = included.filter((item) => item.type === "repository");
+        console.log(repositories);
       } catch (err) {
         console.error(err);
       }
@@ -77,11 +78,12 @@ window.orbit = () => ({
     const currentWorkspace = this.workspaces.filter(
       (item) => item.attributes.slug === this.selectedWorkspaceSlug
     )[0];
-    const allRepoIdsForCurrentWorkspace = currentWorkspace.relationships.repositories.data.reduce(
-      (repoIdsAccumulator, repositoryData) =>
-        (repoIdsAccumulator = repoIdsAccumulator.concat([repositoryData.id])),
-      []
-    );
+    const allRepoIdsForCurrentWorkspace =
+      currentWorkspace.relationships.repositories.data.reduce(
+        (repoIdsAccumulator, repositoryData) =>
+          (repoIdsAccumulator = repoIdsAccumulator.concat([repositoryData.id])),
+        []
+      );
     const result = allRepoIdsForCurrentWorkspace.map(
       (repositoryId) =>
         this.repositories.filter(
@@ -90,20 +92,66 @@ window.orbit = () => ({
     );
     return result;
   },
+  _persistRepositories(workspaceSlug, repositories) {
+    // Addresses of the chunked repositories so we can retrieve them later
+    let repository_keys = [];
+
+    // Used to number the chunked repository keys
+    let j = 1;
+
+    // Break repositories down into chunks of 100 &
+    // store them separately
+    // IE if there are 240 repositories, they will be saved as:
+    //
+    // sally:repositories:1 // Repositories 0-100
+    // sally:repositories:2 // Repositories 101-200
+    // sally:repositories:3 // Repositories 201-240
+    while (repositories.length > 0) {
+      let key = `${workspaceSlug}:repositories:${j}`;
+
+      repository_keys.push(key);
+      chrome.storage.sync.set({
+        [key]: repositories.splice(0, 100),
+      });
+      j++;
+    }
+
+    return repository_keys;
+  },
+  _buildStorageObject(token, workspaceSlug, repositories) {
+    const storageObject = {};
+
+    // Set common variables
+    storageObject["token"] = token;
+    storageObject["workspace"] = workspaceSlug;
+    storageObject["repository_keys"] = this._persistRepositories(
+      workspaceSlug,
+      repositories
+    );
+
+    return storageObject;
+  },
   save() {
     let that = this;
-    let repositoriesFullNameForWorkspace = this._findAllReposFullNameByWorkspaceSlug();
-    chrome.storage.sync.set(
-      {
-        token: this.token,
-        workspace: this.selectedWorkspaceSlug,
-        repositories: repositoriesFullNameForWorkspace,
-      },
-      function () {
-        that.saveStatus.success = true;
-        that.saveStatus.message =
-          "Saved successfully, you can close this page.";
-      }
+    let repositoriesFullNameForWorkspace =
+      this._findAllReposFullNameByWorkspaceSlug();
+
+    let storageData = this._buildStorageObject(
+      this.token,
+      this.selectedWorkspaceSlug,
+      repositoriesFullNameForWorkspace
     );
+
+    chrome.storage.sync.set(storageData, function () {
+      that.saveStatus.success = true;
+      that.saveStatus.message = "Saved successfully, you can close this page.";
+    });
+
+    // TESTING: Retrieving & logging the stored data
+    chrome.storage.sync.get("repository_keys", ({ repository_keys }) => {
+      chrome.storage.sync.get(repository_keys[0], (repositories) => {
+        console.log("Repositories", repositories);
+      });
+    });
   },
 });


### PR DESCRIPTION
Context from issue:

> Indeed, from the [chrome.storage docs](https://developer.chrome.com/docs/extensions/reference/storage/#property-sync) it looks like items in the storage must not exceed 8Kb (around 8k chars apparently).

Historical structure of chrome storage:

```
{
  token: 123 // Users API token,
  workspace: 'sally' // Slug of selected workspace
  repositories: ['repo-1', 'repo-2', ...., 'repo-224'] // Slugs of all repositories for that workspace
} 
```

Storing too many repositories under one key caused this to break.

New structure:

```
{
  token: 123 // Users API token,
  workspace: 'sally' // Slug of selected workspace
  repository_keys: ['sally:repositories:1', 'sally:repositories:2' ] // Keys to retrieve each chunk of 100 repositories
  sally:repositories:1: ['repo-1', 'repo-2', .... 'repo-100'] // A chunk of maximum 100 repositories
  sally:repositories:2: ['repo-101', 'repo-102', .... 'repo-224'] // A chunk of maximum 100 repositories
} 
```

This PR updates the read/write processes for our data to chunk it up, and then reform the chunks into one array when read.

Closes https://github.com/orbit-love/orbit-browser-extension/issues/26