### PR TITLE
Fix: show widget when navigating from repository homepage

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,12 +10,8 @@
   "content_scripts": [
     {
       "run_at": "document_start",
-      "matches": [
-        "https://github.com/*/*/pulls*",
-        "https://github.com/*/*/pull/*",
-        "https://github.com/*/*/issues*",
-        "https://github.com/*/*/discussions*"
-      ],
+      "matches": ["https://github.com/*"],
+      "exclude_matches": ["https://*/login/*"],
       "css": ["github/orbit-action.css"],
       "js": ["github/background.js"]
     }


### PR DESCRIPTION
Fixes #34

You can test the fix by navigating to an issue/PR/discussion from a repository homepage—it should display the widget on this branch, but it doesn’t on `main`.