### PR TITLE
Remove ability to add comment as content; improve logged out experience

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,12 +1,21 @@
 // When clicking on the Orbit extension button, open the options page
-chrome.browserAction.onClicked.addListener(() => chrome.runtime.openOptionsPage());
+chrome.browserAction.onClicked.addListener(() =>
+  chrome.runtime.openOptionsPage()
+);
 
-const isFirstInstall = async (suggestedReason) => suggestedReason === 'install'
+const isFirstInstall = async (suggestedReason) => suggestedReason === "install";
 
 // When installing the Orbit extension, open the options page
-chrome.runtime.onInstalled.addListener(async ({reason}) => {
-	// Only notify on install
-	if (await isFirstInstall(reason)) {
-		chrome.runtime.openOptionsPage()
-	}
+chrome.runtime.onInstalled.addListener(async ({ reason }) => {
+  // Only notify on install
+  if (await isFirstInstall(reason)) {
+    chrome.runtime.openOptionsPage();
+  }
+});
+
+// When receiving the "showOptions" message, open the options page
+chrome.runtime.onMessage.addListener((request) => {
+  if (request === "showOptions") {
+    chrome.runtime.openOptionsPage();
+  }
 });

--- a/src/github/github.js
+++ b/src/github/github.js
@@ -70,28 +70,10 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       const gitHubUsername = authorElement.innerText;
 
-      const relativeTimeElement = comment.querySelector("relative-time");
-
-      if (!relativeTimeElement) {
-        break;
-      }
-
-      const commentUrl =
-        window.location.href +
-        relativeTimeElement.parentElement.getAttribute("href");
-
-      const commentPublishedAt = relativeTimeElement.getAttribute("datetime");
-
-      if (!commentPublishedAt) {
-        break;
-      }
-
       const orbitActionElement = await createOrbitDetailsElement(
         ORBIT_CREDENTIALS,
         gitHubUsername,
-        isRepoInWorkspace,
-        commentUrl,
-        commentPublishedAt
+        isRepoInWorkspace
       );
 
       // The element must be inserted at different places if it's in a Discussions message

--- a/src/github/orbit-action.js
+++ b/src/github/orbit-action.js
@@ -195,13 +195,16 @@ export async function createOrbitDetailsElement(
 
   function insertContentWhenNoCredentials() {
     const missingCredentialsInfo1 = createDropdownItem(
-      "API token or workspace is missing"
+      "Authentication error: API token or workspace is missing."
     );
     $detailsMenuElement.appendChild(missingCredentialsInfo1);
 
     const missingCredentialsInfo2 = createDropdownItem(
-      "Right click the extension icon to access Options"
+      "Click here or on the extension icon to authenticate."
     );
+    missingCredentialsInfo2.addEventListener('click', () => {
+      chrome.runtime.sendMessage("showOptions");
+    })
     $detailsMenuElement.appendChild(missingCredentialsInfo2);
   }
 

--- a/src/github/orbit-action.js
+++ b/src/github/orbit-action.js
@@ -30,9 +30,7 @@ import { ORBIT_API_ROOT_URL } from "../constants";
 export async function createOrbitDetailsElement(
   ORBIT_CREDENTIALS,
   gitHubUsername,
-  isRepoInWorkspace,
-  commentUrl,
-  commentPublishedAt
+  isRepoInWorkspace
 ) {
   /**
    * As a convention, $variables are “state variables” which can be updated in any
@@ -307,24 +305,6 @@ export async function createOrbitDetailsElement(
     $detailsMenuElement.appendChild(dropdownDivider2);
 
     /**
-     * <a href="…">Add to to X’s content</a>
-     */
-    const detailsMenuLinkContent = window.document.createElement("a");
-    detailsMenuLinkContent.setAttribute(
-      "aria-label",
-      `Add to ${gitHubUsername}’s content`
-    );
-    detailsMenuLinkContent.setAttribute("role", "menuitem");
-    detailsMenuLinkContent.classList.add(
-      "dropdown-item",
-      "dropdown-item-orbit",
-      "btn-link"
-    );
-    detailsMenuLinkContent.textContent = `Add to ${gitHubUsername}’s content`;
-    detailsMenuLinkContent.addEventListener("click", handleAddCommentToMember);
-    $detailsMenuElement.appendChild(detailsMenuLinkContent);
-
-    /**
      * <a href="…">See X’s profile on Orbit</a>
      */
     const detailsMenuLinkProfile = window.document.createElement("a");
@@ -343,31 +323,6 @@ export async function createOrbitDetailsElement(
     );
     detailsMenuLinkProfile.textContent = `See ${gitHubUsername}’s profile on Orbit`;
     $detailsMenuElement.appendChild(detailsMenuLinkProfile);
-  }
-
-  async function handleAddCommentToMember(event) {
-    event.target.removeEventListener("click", handleAddCommentToMember);
-    event.preventDefault();
-    event.stopPropagation();
-    event.target.textContent = "Adding the content…";
-
-    const { success, id } = await orbitAPI.addCommentAsContentToMember(
-      ORBIT_CREDENTIALS,
-      $slug,
-      commentUrl,
-      commentPublishedAt
-    );
-    if (success) {
-      event.target.setAttribute(
-        "href",
-        `${ORBIT_API_ROOT_URL}/${normalizedWorkspace}/activities/${id}`
-      );
-      event.target.setAttribute("target", "_blank");
-      event.target.setAttribute("rel", "noopener");
-      event.target.textContent = `Added! See ${gitHubUsername}’s content on Orbit`;
-    } else {
-      event.target.textContent = `There was a problem with the request.`;
-    }
   }
 
   /**

--- a/src/github/orbit-action.test.js
+++ b/src/github/orbit-action.test.js
@@ -188,39 +188,3 @@ test("should create new members for non-members", async () => {
     );
   });
 });
-
-test("should create content for existing members", async () => {
-  global.fetch.mockImplementationOnce(
-    mockOrbitAPICall({ data: { id: 12 } }, true, 201)
-  );
-  fireEvent(
-    getByRole(orbitDetailsElement, "button"),
-    new MouseEvent("mouseover")
-  );
-  await waitFor(() => {
-    expect(getByText(orbitDetailsElement, "Add to phacks’s content"));
-  });
-  global.fetch.mockClear();
-  fireEvent(
-    getByText(orbitDetailsElement, "Add to phacks’s content"),
-    new MouseEvent("click")
-  );
-  await waitFor(() => {
-    expect(getByText(orbitDetailsElement, "Adding the content…"));
-  });
-  expect(global.fetch).toHaveBeenCalledWith(
-    expect.stringContaining("/my-workspace/members/phacks/activities"),
-    expect.objectContaining({
-      body: JSON.stringify({
-        activity_type: "content",
-        url: "https://github.com/orbit-love/orbit-model/issues/10#issuecomment-590037251",
-        occurred_at: "2020-02-23T07:55:28Z"
-      })
-    })
-  );
-  await waitFor(() => {
-    expect(
-      getByText(orbitDetailsElement, "Added! See phacks’s content on Orbit")
-    );
-  });
-});

--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -219,57 +219,8 @@ export const orbitAPI = {
         success: false,
       };
     }
-  },
-  /**
-   * Adds the current comment as an Orbit content to the member
-   *
-   * @param {*} ORBIT_CREDENTIALS the Orbit credentials
-   * @param {*} member the member slug to add the content to
-   *
-   * @returns {success, status}
-   */
-  async addCommentAsContentToMember(
-    ORBIT_CREDENTIALS,
-    member,
-    commentUrl,
-    commentPublishedAt
-  ) {
-    try {
-      const response = await fetch(
-        `${ORBIT_API_ROOT_URL}/${ORBIT_CREDENTIALS.WORKSPACE}/members/${member}/activities?api_key=${ORBIT_CREDENTIALS.API_TOKEN}`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            activity_type: "content",
-            url: commentUrl,
-            occurred_at: commentPublishedAt,
-          }),
-          headers: {
-            "Content-Type": "application/json",
-            ...ORBIT_HEADERS,
-          },
-        }
-      );
-      if (!response.ok) {
-        return {
-          success: false,
-          status: response.status,
-        };
-      }
-      const { data } = await response.json();
-      return {
-        success: true,
-        id: data.id,
-        status: response.status,
-      };
-    } catch (err) {
-      console.error(err);
-      return {
-        success: false,
-      };
-    }
-  },
-};
+  }
+}
 
 /**
  * Returns the current repository full name based on the current URL.

--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -289,12 +289,12 @@ export function _getRepositoryFullName() {
  * @returns Array<String> a 1d array of all repsoitory names, ie ["repo-1", "repo-2"]
  */
 export async function _fetchRepositories() {
-  const { repository_keys } = await chrome.storage.sync.get("repository_keys");
+  const { repository_keys } = await chrome.storage.sync.get({ repository_keys: [] });
 
   // Backwards compatibility - if we do not have repository keys,
   //  default to how we used to store them
   if (repository_keys === undefined) {
-    const { repositories } = await chrome.storage.sync.get("repositories");
+    const { repositories } = await chrome.storage.sync.get({ repositories: []});
 
     return repositories;
   }

--- a/src/github/orbit-helpers.js
+++ b/src/github/orbit-helpers.js
@@ -244,7 +244,7 @@ export async function _fetchRepositories() {
 
   // Backwards compatibility - if we do not have repository keys,
   //  default to how we used to store them
-  if (repository_keys === undefined) {
+  if (repository_keys.length === 0) {
     const { repositories } = await chrome.storage.sync.get({ repositories: []});
 
     return repositories;


### PR DESCRIPTION
This PR removes a long-unused feature (“Add to Jane’s content”) and improves the experience when the user has not yet logged in, or has not chosen a workspace, or has rotated their API token.

**Removing the “Add to Jane’s content” feature**

This feature was added waaaay back when the Orbit GitHub integration was not as powerful as it is now. How one should/would use it is not clear, since PR/Issues/Discussion comments on one’s repositories are saved in Orbit anyway. Our logs show that it has been unused for at least the last 4 months.
Removing this feature makes the code a bit lighter to reason about and makes future changes easier.

| Before | After |
|--------|--------|
| <img width="341" alt="CleanShot 2023-05-02 at 11 18 28@2x" src="https://user-images.githubusercontent.com/2587348/235628470-a423949d-d85b-4f6a-b9ab-9cbfe471b7ed.png"> | <img width="307" alt="CleanShot 2023-05-02 at 11 19 13@2x" src="https://user-images.githubusercontent.com/2587348/235628572-d2bfd40b-a075-4240-84da-e31c146b3a9d.png"> | 

**Better UX when there is an authentication issue**

- Fixes an issue where the extension button would not show when the repositories were not loaded
- Body copy tweaks to the error message
- On clicking the last item in the dropdown, redirect the user to the options page

<img width="428" alt="CleanShot 2023-05-02 at 11 21 21@2x" src="https://user-images.githubusercontent.com/2587348/235629300-915d9847-96e9-4283-95e1-17986d109917.png">