### PR TITLE
Add support for twitter profile pages

### DIFF
--- a/src/components/twitterButton.js
+++ b/src/components/twitterButton.js
@@ -1,5 +1,5 @@
 import { LitElement, html } from "lit";
-import { unsafeSVG } from "lit/directives/unsafe-svg";
+import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 import { customElement } from "lit/decorators.js";
 import { TailwindMixin } from "../utils/tailwindMixin";
 
@@ -17,7 +17,7 @@ class TwitterButton extends TailwindMixin(LitElement) {
           aria-expanded="true"
           aria-haspopup="true"
         >
-          <span class="sr-only">Open options</span>
+          <span class="sr-only">Open Orbit Widget</span>
           ${unsafeSVG(orbitLogo)}
         </button>
       </div>

--- a/src/components/twitterButton.js
+++ b/src/components/twitterButton.js
@@ -1,0 +1,26 @@
+import { LitElement, html } from "lit";
+import { unsafeSVG } from "lit/directives/unsafe-svg";
+import { customElement } from "lit/decorators.js";
+import { TailwindMixin } from "../utils/tailwindMixin";
+
+import orbitLogo from "bundle-text:../icons/orbit-logo.svg";
+
+@customElement("obe-twitter-button")
+class TwitterButton extends TailwindMixin(LitElement) {
+  render() {
+    return html`
+      <div>
+        <button
+          type="button"
+          class="min-w-[36px] min-h-[36px] mr-[8px] mb-[12px] text-[#0f1419] dark:text-[#eff3f4] hover:bg-[#0f14191A] rounded-full border border-[#cfd9de] dark:border-[#536471] flex justify-center items-center"
+          id="menu-button"
+          aria-expanded="true"
+          aria-haspopup="true"
+        >
+          <span class="sr-only">Open options</span>
+          ${unsafeSVG(orbitLogo)}
+        </button>
+      </div>
+    `;
+  }
+}

--- a/src/components/widget.js
+++ b/src/components/widget.js
@@ -157,7 +157,7 @@ class Widget extends TailwindMixin(LitElement) {
               this.member.lastActivityOccurredAt &&
               html` <obe-pill
                 name="Last active"
-                value="${_formatDate(this.member.lastActivityOccurredAt)}"
+                value="${this._formatDate(this.member.lastActivityOccurredAt)}"
               ></obe-pill>`
             }
           </section>

--- a/src/pages/githubDiscussionPage.js
+++ b/src/pages/githubDiscussionPage.js
@@ -14,6 +14,8 @@ export default class GitHubDiscussionPage extends Page {
     return widgetZone.querySelector(".timeline-comment-actions") !== null;
   }
 
+  applyCSSPatch() {}
+
   findUsername(comment) {
     const authorElement =
       comment.querySelector('a > img[class~="avatar"] + div > span') ||

--- a/src/pages/twitterProfilePage.js
+++ b/src/pages/twitterProfilePage.js
@@ -43,11 +43,15 @@ export default class TwitterProfilePage extends Page {
   }
 
   findUsername(main) {
-    return main
-      .querySelector("div[data-testid='UserName']")
-      ?.children[0]?.children[0]?.children[1]?.children[0]?.children[0]?.children[0]?.children[0]?.innerHTML?.slice(
-        1
-      );
+    /**
+     * The headerPhoto element here is a link surrounding the, well, header photo,
+     * which links to "/<username>/header_photo"
+     */
+    const headerPhoto = main.querySelector('a[href$="/header_photo"]');
+
+    if (!headerPhoto) { return }
+
+    return headerPhoto.getAttribute('href').split('/')[1];
   }
 
   findInsertionPoint(main) {

--- a/src/pages/twitterProfilePage.js
+++ b/src/pages/twitterProfilePage.js
@@ -1,0 +1,59 @@
+import Page from "./page";
+
+export default class TwitterProfilePage extends Page {
+  detect() {
+    /**
+     * Since Twitter doesn't have a specific URL pattern for profile
+     * pages, we look for a header photo instead. Conveniently, they always
+     * seem to link to "/<username>/header_photo"
+     */
+    return document.querySelector('a[href$="/header_photo"]');    
+  }
+
+  findWidgetZones() {
+    return window.document.getElementsByTagName("main");
+  }
+
+  validateWidgetZone(_widgetZone) {
+    return true;
+  }
+
+  applyCSSPatch(main) {
+    /**
+     * Twitter's CSS is unwieldly, and elements seems to stack on top of
+     * one another, covering the ones below. To avoid the widget to be covered by
+     * the bio and tweet timeline, we apply a z-index: 1 to two elements.
+     */
+    const primaryColumnElement = main.querySelector(
+      "div[data-testid='primaryColumn']"
+    );
+    const headerElement =
+      primaryColumnElement?.children[0]?.children[2]?.children[0]?.children[0]
+        ?.children[0];
+
+    if (headerElement) {
+      headerElement.setAttribute("style", "z-index: 1;");
+      const actionButtonsContainerElement =
+        headerElement.children[1]?.children[0];
+
+      if (actionButtonsContainerElement) {
+        actionButtonsContainerElement.setAttribute("style", "z-index: 1;");
+      }
+    }
+  }
+
+  findUsername(main) {
+    return main
+      .querySelector("div[data-testid='UserName']")
+      ?.children[0]?.children[0]?.children[1]?.children[0]?.children[0]?.children[0]?.children[0]?.innerHTML?.slice(
+        1
+      );
+  }
+
+  findInsertionPoint(main) {
+    return (
+      main.querySelector("div[data-testid='UserName']")?.parentElement?.children[0]?.children[1] ||
+      null
+    );
+  }
+}

--- a/src/pages/twitterProfilePage.js
+++ b/src/pages/twitterProfilePage.js
@@ -7,7 +7,7 @@ export default class TwitterProfilePage extends Page {
      * pages, we look for a header photo instead. Conveniently, they always
      * seem to link to "/<username>/header_photo"
      */
-    return document.querySelector('a[href$="/header_photo"]');    
+    return !!document.querySelector('a[href$="/header_photo"]');
   }
 
   findWidgetZones() {

--- a/src/pages/twitterProfilePage.test.js
+++ b/src/pages/twitterProfilePage.test.js
@@ -1,0 +1,23 @@
+import TwitterProfilePage from "./twitterProfilePage";
+
+describe("TwitterProfilePage", () => {
+  let page;
+
+  beforeEach(() => {
+    page = new TwitterProfilePage();
+  });
+
+  describe("#detect", () => {
+    it("detects header photos", () => {
+      const headerPhoto = document.createElement("a");
+      headerPhoto.setAttribute('href', '/OrbitModel/header_photo');
+      document.body.appendChild(headerPhoto);
+      expect(page.detect()).toBe(true);
+      document.body.removeChild(headerPhoto);
+    });
+
+    it("does not recognise other pages", () => {
+      expect(page.detect()).toBe(false);
+    });
+  });
+});

--- a/src/widget/githubEntrypoint.js
+++ b/src/widget/githubEntrypoint.js
@@ -1,7 +1,9 @@
 import "chrome-extension-async";
 import "@webcomponents/custom-elements";
-import GitHubIssueOrPullRequestPage from "../pages/githubIssueOrPullRequestPage";
+
 import WidgetOrchestrator from "./widgetOrchestrator";
+
+import GitHubIssueOrPullRequestPage from "../pages/githubIssueOrPullRequestPage";
 import GitHubDiscussionPage from "../pages/githubDiscussionPage";
 
 /**

--- a/src/widget/twitterEntrypoint.js
+++ b/src/widget/twitterEntrypoint.js
@@ -1,0 +1,50 @@
+import "chrome-extension-async";
+import "@webcomponents/custom-elements";
+import elementReady from "element-ready";
+
+import WidgetOrchestrator from "./widgetOrchestrator";
+
+import TwitterProfilePage from "../pages/twitterProfilePage";
+
+/**
+ * 
+ */
+const initializeWidget = () => {
+  const pages = [ new TwitterProfilePage() ];
+
+  const orchestrator = new WidgetOrchestrator();
+
+  const page = orchestrator.detectPage(pages);
+  if (!page) return;
+
+  orchestrator.addWidgetElements(page, "twitter");
+}
+
+async function setupObserver() {
+  const titleElement = await elementReady('head > title', { stopOnDomReady: false, timeout: 5000 });
+
+  if (!titleElement) { return }
+
+  const observer = new MutationObserver((mutationList, _observer) => {
+    // We only want to initialize the widget once the page is fully loaded.
+    // We can detect this using the <title> as it shows the username (@something) when the
+    // page has loaded, but not before
+    mutationList.forEach((mutation) => {
+      if (!mutation.type === 'childList') { return }
+
+      const newTitle = mutation.addedNodes[0]?.textContent
+
+      if (newTitle === undefined || newTitle.indexOf('@') === -1) { return }
+
+      initializeWidget();
+    });
+  });
+  
+  observer.observe(titleElement, {
+    subtree: true,
+    childList: true,
+    characterData: true
+  });
+}
+
+setupObserver();

--- a/src/widget/twitterEntrypoint.js
+++ b/src/widget/twitterEntrypoint.js
@@ -6,9 +6,6 @@ import WidgetOrchestrator from "./widgetOrchestrator";
 
 import TwitterProfilePage from "../pages/twitterProfilePage";
 
-/**
- * 
- */
 const initializeWidget = () => {
   const pages = [ new TwitterProfilePage() ];
 

--- a/src/widget/widgetOrchestrator.js
+++ b/src/widget/widgetOrchestrator.js
@@ -22,13 +22,14 @@ export default class WidgetOrchestrator {
    * @param {string} platform the site we're on, used as a key for naming HTML elements
    */
   addWidgetElements(page, platform) {
-    if (document.querySelector('obe-widget')) {
-      return;
-    }
 
     const widgetZones = page.findWidgetZones();
 
     for (const widgetZone of widgetZones) {
+      if (widgetZone.querySelector('obe-widget')) {
+        return;
+      }
+
       if (!page.validateWidgetZone(widgetZone)) break;
 
       page.applyCSSPatch(widgetZone);

--- a/src/widget/widgetOrchestrator.js
+++ b/src/widget/widgetOrchestrator.js
@@ -1,6 +1,7 @@
 import { Page } from "../pages/page";
 import "../components/widget";
 import "../components/githubButton";
+import "../components/twitterButton";
 
 export default class WidgetOrchestrator {
   /**
@@ -21,6 +22,10 @@ export default class WidgetOrchestrator {
    * @param {string} platform the site we're on, used as a key for naming HTML elements
    */
   addWidgetElements(page, platform) {
+    if (document.querySelector('obe-widget')) {
+      return;
+    }
+
     const widgetZones = page.findWidgetZones();
 
     for (const widgetZone of widgetZones) {


### PR DESCRIPTION
This PR adds support for displaying the Orbit widget on Twitter profile pages:

<img width="892" alt="CleanShot 2023-05-25 at 12 19 49@2x" src="https://github.com/orbit-love/orbit-browser-extension/assets/2587348/81df9864-c8ba-4f7a-aa8b-c13081c8a15c">

Compared to the initial prototype, this adds a couple of improvements:

- Profile page detection does not rely on the URL anymore (it was too hit-and-miss) but on the presence of a header photo (which in my testing seems to be much more reliable)
- I added a mechanism to prevent a widget to be instantiated if there is already one present on a given WidgetZone

To test, update the `manifest.json` file as follows:

```diff
diff --git a/src/manifest.json b/src/manifest.json
index 56faacb..c42e983 100644
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,14 @@
       "matches": ["https://github.com/*"],
       "exclude_matches": ["https://*/login/*"],
       "css": ["github/orbit-action.css"],
       "js": ["github/github.js"]
+    },
+    {
+      "run_at": "document_start",
+      "matches": [
+        "https://twitter.com/*"
+      ],
+      "js": ["widget/twitterEntrypoint.js"]
     }
   ],
   "browser_action": {
```