### PR TITLE
Add the widget to LinkedIn profile pages

### DIFF
--- a/src/components/linkedinButton.js
+++ b/src/components/linkedinButton.js
@@ -1,0 +1,26 @@
+import {LitElement, html, css} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
+import { TailwindMixin } from "../utils/tailwindMixin";
+
+import orbitLogo from 'bundle-text:../icons/orbit-logo.svg'
+
+@customElement('obe-linkedin-button')
+class LinkedinButton extends TailwindMixin(LitElement) {
+  static styles = css`
+    .orbit-logo {
+      @apply relative left-[1px]
+    }
+  `
+
+  render() {
+    return html`
+      <div>
+        <button type="button" class="w-[40px] h-[40px] text-[#00000099] hover:bg-[#00000014] rounded-full flex justify-center items-center" id="menu-button" aria-expanded="true" aria-haspopup="true">
+          <span class="sr-only">Open options</span>
+          ${unsafeSVG(orbitLogo)}
+        </button>
+      </div>
+    `
+  }
+}

--- a/src/pages/linkedinProfilePage.js
+++ b/src/pages/linkedinProfilePage.js
@@ -1,0 +1,27 @@
+import Page from "./page";
+
+export default class LinkedinProfilePage extends Page {
+  detect() {
+    const pathname = window.location.pathname;
+    return pathname.startsWith("/in/");
+  }
+
+  findWidgetZones() {
+    return window.document.getElementsByTagName("main");
+  }
+
+  validateWidgetZone(_widgetZone) {
+    return true;
+  }
+
+  applyCSSPatch() {}
+
+  findUsername(_main) {
+    const pathname = window.location.pathname;
+    return pathname.match(/.*(\/in\/)([\w\d_-]*)\/?/)[2];
+  }
+
+  findInsertionPoint(main) {
+    return main.querySelector(".pv-top-card__badge-wrap") || null
+  }
+}

--- a/src/pages/linkedinProfilePage.test.js
+++ b/src/pages/linkedinProfilePage.test.js
@@ -1,0 +1,48 @@
+import LinkedinProfilePage from "./linkedinProfilePage";
+
+describe("LinkedinProfilePage", () => {
+  let page, originalLocation;
+
+  beforeEach(() => {
+    page = new LinkedinProfilePage();
+    originalLocation = window.location;
+  });
+
+  afterEach(() => {
+    window.location = originalLocation;
+  });
+
+  describe("#detect", () => {
+    it("recognises profile pages", () => {
+      delete window.location;
+      window.location = {
+        ...originalLocation,
+        pathname: "/in/nicolas-goutay-4b984258",
+      };
+
+      expect(page.detect()).toBe(true);
+    });
+
+    it("does not recognise other pages", () => {
+      delete window.location;
+      window.location = {
+        ...originalLocation,
+        pathname: "/feed",
+      };
+
+      expect(page.detect()).toBe(false);
+    });
+  });
+
+  describe("#findUsername", () => {
+    it("extracts the username from the pathname", () => {
+      delete window.location;
+      window.location = {
+        ...originalLocation,
+        pathname: "/in/nicolas-goutay-4b984258",
+      };
+
+      expect(page.findUsername()).toBe('nicolas-goutay-4b984258');
+    });
+  })
+});

--- a/src/widget/linkedinEntrypoint.js
+++ b/src/widget/linkedinEntrypoint.js
@@ -1,0 +1,36 @@
+import "chrome-extension-async";
+import "@webcomponents/custom-elements";
+import elementReady from "element-ready";
+
+import WidgetOrchestrator from "./widgetOrchestrator";
+
+import LinkedinProfilePage from "../pages/linkedinProfilePage";
+
+const initializeWidget = () => {
+  const pages = [ new LinkedinProfilePage() ];
+
+  const orchestrator = new WidgetOrchestrator();
+
+  const page = orchestrator.detectPage(pages);
+  if (!page) return;
+
+  orchestrator.addWidgetElements(page, "linkedin");
+}
+
+async function setupObserver() {
+  const titleElement = await elementReady('head > title', { stopOnDomReady: false, timeout: 5000 });
+
+  if (!titleElement) { return }
+
+  const observer = new MutationObserver((mutationList, _observer) => {
+    initializeWidget();
+  });
+  
+  observer.observe(titleElement, {
+    subtree: true,
+    childList: true,
+    characterData: true
+  });
+}
+
+setupObserver();

--- a/src/widget/widgetOrchestrator.js
+++ b/src/widget/widgetOrchestrator.js
@@ -2,6 +2,7 @@ import { Page } from "../pages/page";
 import "../components/widget";
 import "../components/githubButton";
 import "../components/twitterButton";
+import "../components/linkedinButton";
 
 export default class WidgetOrchestrator {
   /**


### PR DESCRIPTION
This PR adds support for displaying the Orbit widget on LinkedIn profile pages:

![CleanShot 2023-05-25 at 14 16 28@2x](https://github.com/orbit-love/orbit-browser-extension/assets/2587348/ba813be5-711d-4d58-a9d2-2c8ed3739bfd)

(This is really fun! :D)

To test, update the manifest.json file as follows:

```diff
diff --git a/src/manifest.json b/src/manifest.json
index 56faacb..3af61e1 100644
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,21 @@
       "matches": ["https://github.com/*"],
       "exclude_matches": ["https://*/login/*"],
       "css": ["github/orbit-action.css"],
       "js": ["github/github.js"]
+    },
+    {
+      "run_at": "document_start",
+      "matches": [
+        "https://www.linkedin.com/*"
+      ],
+      "js": ["widget/linkedinEntrypoint.js"]
     }
   ],
   "browser_action": {
```