### PR TITLE
Add the widget to GMail email threads

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -146,10 +146,17 @@ const loadMemberData = async ({ username, platform, ORBIT_CREDENTIALS }) => {
     `${ORBIT_API_ROOT_URL}/${ORBIT_CREDENTIALS.WORKSPACE}/members/find`
   );
 
-  const { params, headers } = configureRequest(ORBIT_CREDENTIALS, {
-    source: platform,
-    username: username,
-  });
+  let payload;
+  switch(platform) {
+    case 'gmail':
+      payload = { source: 'email', email: username }
+      break;
+    default:
+      payload = { source: platform, username }
+      break;
+  }
+
+  const { params, headers } = configureRequest(ORBIT_CREDENTIALS, payload);
 
   url.search = params.toString();
 

--- a/src/components/gmailButton.js
+++ b/src/components/gmailButton.js
@@ -1,0 +1,60 @@
+import { LitElement, html, css, unsafeCSS } from "lit";
+import { unsafeSVG } from "lit/directives/unsafe-svg.js";
+import { customElement } from "lit/decorators.js";
+
+import tailwindStylesheet from "bundle-text:../styles/tailwind.global.css";
+import orbitLogo from "bundle-text:../icons/orbit-logo.svg";
+
+@customElement("obe-gmail-button")
+class GmailButton extends LitElement {
+  static styles = [
+    unsafeCSS(tailwindStylesheet),
+    // Gmail buttons "hover" effect is built with ::before attributes and CSS transitions
+    // These properties have been copied from the other buttons
+    css`
+      button::before {
+        content: "";
+        display: block;
+        opacity: 0;
+        position: absolute;
+        transition-duration: .15s;
+        transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+        z-index: -1;
+        bottom: -10px;
+        left: -10px;
+        right: -10px;
+        top: -10px;
+        background: none;
+        border-radius: 50%;
+        box-sizing: border-box;
+        transform: scale(0);
+        transition-property: transform,opacity;
+      }
+
+      button:hover::before {
+        background-color: rgba(32, 33, 36, 0.059);
+        border: none;
+        box-shadow: none;
+        opacity: 1;
+        transform: scale(1);
+      }
+    `
+  ];
+
+  render() {
+    return html`
+      <div>
+        <button
+          type="button"
+          class="relative top[-1px] z-0 w-[20px] h-[20px] ml-[20px] mb-[12px] text-[#454746] rounded-full flex justify-center items-center"
+          id="menu-button"
+          aria-expanded="true"
+          aria-haspopup="true"
+        >
+          <span class="sr-only">Open Orbit Widget</span>
+          ${unsafeSVG(orbitLogo)}
+        </button>
+      </div>
+    `;
+  }
+}

--- a/src/pages/gmailEmailThreadPage.js
+++ b/src/pages/gmailEmailThreadPage.js
@@ -13,7 +13,7 @@ export default class GmailEmailThreadPage extends Page {
   }
 
   findWidgetZones() {
-    return window.document.querySelectorAll("[role='listitem'][aria-expanded='true'] [data-message-id]");
+    return window.document.querySelectorAll("[role='listitem'] [data-message-id]");
   }
 
   validateWidgetZone(_expandedEmail) {
@@ -23,7 +23,7 @@ export default class GmailEmailThreadPage extends Page {
   applyCSSPatch(_expandedEmail) {}
 
   findUsername(expandedEmail) {
-    return expandedEmail.querySelector("span[email]").getAttribute("email");
+    return expandedEmail.querySelector("span[email]")?.getAttribute("email");
   }
 
   findInsertionPoint(expandedEmail) {

--- a/src/pages/gmailEmailThreadPage.js
+++ b/src/pages/gmailEmailThreadPage.js
@@ -1,0 +1,32 @@
+import Page from "./page";
+
+export default class GmailEmailThreadPage extends Page {
+  detect() {
+    const topLevelPageRegex =
+      /(#inbox|#starred|#snoozed|#sent|#scheduled|#drafts|#imp|#all|#spam|#trash)\/\w+/;
+    const secondLevelPageRegex = /(#category|#label|#search|#advanced-search)\/[^\/]+\/\w+/;
+
+    return (
+      topLevelPageRegex.test(window.location.hash) ||
+      secondLevelPageRegex.test(window.location.hash)
+    );
+  }
+
+  findWidgetZones() {
+    return window.document.querySelectorAll("[role='listitem'][aria-expanded='true'] [data-message-id]");
+  }
+
+  validateWidgetZone(_expandedEmail) {
+    return true;
+  }
+
+  applyCSSPatch(_expandedEmail) {}
+
+  findUsername(expandedEmail) {
+    return expandedEmail.querySelector("span[email]").getAttribute("email");
+  }
+
+  findInsertionPoint(expandedEmail) {
+    return expandedEmail.querySelector('td [rowspan="2"]');
+  }
+}

--- a/src/pages/gmailEmailThreadPage.test.js
+++ b/src/pages/gmailEmailThreadPage.test.js
@@ -1,0 +1,94 @@
+import GmailEmailThreadPage from "./gmailEmailThreadPage";
+
+describe("GmailEmailThreadPage", () => {
+  let page, originalLocation;
+
+  beforeEach(() => {
+    page = new GmailEmailThreadPage();
+    originalLocation = window.location;
+  });
+
+  afterEach(() => {
+    window.location = originalLocation;
+  });
+
+  describe("#detect", () => {
+    it("detects top-level threads pages in various contexts", () => {
+      // Using sample URLs from my GMail:
+      const topLevelEmailThreadPages = [
+        "#inbox/FMfcgzGsmhgmSZBrHhpDwjWgCPRGcxWQ",
+        "#starred/FMfcgzGrcXrRJHsSStwqswkmmMVbmhhN",
+        "#snoozed/FMfcgzGsmhgmSZBrHhpDwjWgCPRGcxWQ",
+        "#sent/FMfcgzGsmWxxqCZMmqCzQclwWvMNZcJK",
+        "#scheduled/KtbxLthNQSSmlnDGTthLnsPgNRzbgtrCcL",
+        "#drafts/FMfcgzGsmhgmKJKRHNfmCwbmVbxdpdGf",
+        "#imp/FMfcgzGsmhSGtwvkdfbbCsqbMCtpcPFB",
+        "#all/KtbxLthNQSSmlnDGTthLnsPgNRzbgtrCcL",
+        "#spam/FMfcgzGsmhgmSZBPWfBnMjhjBPZgQbSF",
+        "#trash/FMfcgzGsmhgmSZBPWfBnMjhjBPZgQbSF",
+      ];
+
+      for (const topLevelEmailThreadPage of topLevelEmailThreadPages) {
+        delete window.location;
+        window.location = {
+          ...originalLocation,
+          hash: topLevelEmailThreadPage,
+        };
+        expect(page.detect()).toBe(true);
+      }
+    });
+
+    it("detects second-level thread pages in various contexts", () => {
+      // Using sample URLs from my GMail:
+      const secondLevelEmailThreadPages = [
+        "#category/social/FMfcgzGsmhfdkkmpWmCJXwHNbfblxRpm",
+        "#category/updates/FMfcgzGsmhgmKJKRHNfmCwbmVbxdpdGf",
+        "#category/forums/FMfcgzGsmXDbXxbtJNJNFGQRZgMrCjnH",
+        "#category/promotions/FMfcgzGsmhcLDSfWfLpqHrmhvJWjnplW",
+        "#label/My+Label/FMfcgxwLsSWMtGrdNwQgnSqZZLhGFbrT",
+        "#search/my+search/FMfcgzGsmWtVBtqcfngzFbZVmWlgnVSG",
+        "#advanced-search/subset=all&has=my+search&within=1d&sizeoperator=s_sl&sizeunit=s_smb&query=my+search/FMfcgzGsmWtVBtqcfngzFbZVmWlgnVSG"
+      ];
+
+      for (const secondLevelEmailThreadPage of secondLevelEmailThreadPages) {
+        delete window.location;
+        window.location = {
+          ...originalLocation,
+          hash: secondLevelEmailThreadPage,
+        };
+        expect(page.detect()).toBe(true);
+      }
+    });
+
+    it('does not detect "inbox" pages', () => {
+      const inboxPages = [
+        "#inbox",
+        "#starred",
+        "#snoozed",
+        "#sent",
+        "#scheduled",
+        "#drafts",
+        "#imp",
+        "#all",
+        "#spam",
+        "#trash",
+        "#category/social",
+        "#category/updates",
+        "#category/forums",
+        "#category/promotions",
+        "#label/My+Label",
+        "#search/my+search",
+        "#advanced-search/subset=all&has=my+search&within=1d&sizeoperator=s_sl&sizeunit=s_smb&query=my+search"
+      ];
+
+      for (const inboxPage of inboxPages) {
+        delete window.location;
+        window.location = {
+          ...originalLocation,
+          hash: inboxPage,
+        };
+        expect(page.detect()).toBe(false);
+      }
+    });
+  });
+});

--- a/src/widget/gmailEntrypoint.js
+++ b/src/widget/gmailEntrypoint.js
@@ -5,7 +5,17 @@ import WidgetOrchestrator from "./widgetOrchestrator";
 
 import GmailEmailThreadPage from "../pages/gmailEmailThreadPage";
 
+/**
+ * We keep track of the mutation observer so that we can disconnect it
+ * when the user navigates away from an email thread page. This is to avoid
+ * incurring an (admittedly small) performance penalty when browsing around GMail.
+ */
+let observer = new MutationObserver(() => {});
+
 const initializeWidget = () => {
+  // Start by disconnecting the observer
+  if (observer) { observer.disconnect(); }
+
   const pages = [ new GmailEmailThreadPage() ];
 
   const orchestrator = new WidgetOrchestrator();
@@ -14,12 +24,30 @@ const initializeWidget = () => {
   if (!page) return;
 
   orchestrator.addWidgetElements(page, "gmail");
+
+  // Element id=:1 is the "thread view" on thread pages (and also the "inbox view" for inbox pages)
+  const threadElement = document.querySelector('#\\:1');
+
+  if (!threadElement) { return }
+
+  // On changes to the "thread view", rerun the orchestrator again. This is so that we can
+  // track when the user expands an email, and add the widget at that time.
+  observer = new MutationObserver((_mutationList, _observer) => {
+    orchestrator.addWidgetElements(page, "gmail");
+  });
+
+  observer.observe(threadElement, {
+    subtree: true,
+    childList: true
+  });
+
+  return observer;
 }
 
 // I could not find any event fired after the page has finished loading.
 // As a stopgap, we listen for DOMContentLoaded (fired when the loading screen appears)
 // and wait 2s more to be safe.
-document.addEventListener("DOMContentLoaded", () => setTimeout(initializeWidget, 2000));
+document.addEventListener("DOMContentLoaded", () => setTimeout(() => observer = initializeWidget(), 2000));
 
 // Navigating around GMail changes the hash
-window.addEventListener('hashchange', initializeWidget);
+window.addEventListener('hashchange', () => { observer = initializeWidget() });

--- a/src/widget/gmailEntrypoint.js
+++ b/src/widget/gmailEntrypoint.js
@@ -1,0 +1,25 @@
+import "chrome-extension-async";
+import "@webcomponents/custom-elements";
+
+import WidgetOrchestrator from "./widgetOrchestrator";
+
+import GmailEmailThreadPage from "../pages/gmailEmailThreadPage";
+
+const initializeWidget = () => {
+  const pages = [ new GmailEmailThreadPage() ];
+
+  const orchestrator = new WidgetOrchestrator();
+
+  const page = orchestrator.detectPage(pages);
+  if (!page) return;
+
+  orchestrator.addWidgetElements(page, "gmail");
+}
+
+// I could not find any event fired after the page has finished loading.
+// As a stopgap, we listen for DOMContentLoaded (fired when the loading screen appears)
+// and wait 2s more to be safe.
+document.addEventListener("DOMContentLoaded", () => setTimeout(initializeWidget, 2000));
+
+// Navigating around GMail changes the hash
+window.addEventListener('hashchange', initializeWidget);

--- a/src/widget/widgetOrchestrator.js
+++ b/src/widget/widgetOrchestrator.js
@@ -3,6 +3,7 @@ import "../components/widget";
 import "../components/githubButton";
 import "../components/twitterButton";
 import "../components/linkedinButton";
+import "../components/gmailButton";
 
 export default class WidgetOrchestrator {
   /**

--- a/src/widget/widgetOrchestrator.js
+++ b/src/widget/widgetOrchestrator.js
@@ -36,15 +36,15 @@ export default class WidgetOrchestrator {
         existingWidget.remove();
       }
 
-      if (!page.validateWidgetZone(widgetZone)) break;
+      if (!page.validateWidgetZone(widgetZone)) continue;
 
       page.applyCSSPatch(widgetZone);
 
       const username = page.findUsername(widgetZone);
-      if (!username) return;
+      if (!username) continue;
 
       const insertionPoint = page.findInsertionPoint(widgetZone);
-      if (!insertionPoint) return;
+      if (!insertionPoint) continue;
 
       const widgetElement = this.addWidgetElement(username, platform);
       this.addOrbitButton(widgetElement, platform);


### PR DESCRIPTION
This PR adds support for displaying the Orbit widget on GMail email threads:

![CleanShot 2023-05-26 at 15 03 21@2x](https://github.com/orbit-love/orbit-browser-extension/assets/2587348/bcd8276f-8e1f-4030-80fc-ecdc1a66df58)

I’d say the feature is working ~80%, though there are a few quirks that I couldn’t figure out:

- The widget tries to initializes 2 second after the page loaded (e.g. after a page refresh). If the page hasn’t loaded by then, then the widget won’t show. Navigating to another page makes the widget show again though!
- ~~The widget only shows for emails that are _expanded_ upon opening the thread. I’m still looking into this to see if we can make it so that all emails in a thread show the widget.~~ Edit: fixed!

To test, update the manifest.json file as follows:

```diff
diff --git a/src/manifest.json b/src/manifest.json
index 56faacb..d5d612f 100644
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,21 @@
       "matches": ["https://github.com/*"],
       "exclude_matches": ["https://*/login/*"],
       "css": ["github/orbit-action.css"],
       "js": ["github/github.js"]
+    },
+    {
+      "run_at": "document_start",
+      "matches": [
+        "https://mail.google.com/mail/*"
+      ],
+      "js": ["widget/gmailEntrypoint.js"]
     }
   ],
   "browser_action": {
```