### PR TITLE
Fix: always show up-to-date data on LinkedIn

### DIFF
--- a/src/widget/widgetOrchestrator.js
+++ b/src/widget/widgetOrchestrator.js
@@ -27,8 +27,12 @@ export default class WidgetOrchestrator {
     const widgetZones = page.findWidgetZones();
 
     for (const widgetZone of widgetZones) {
-      if (widgetZone.querySelector('obe-widget')) {
-        return;
+      // If a widget already exists for this widgetZone, remove it.
+      // This fixes an issue with SPAs like LinkedIn, where the first widget
+      // that was injected remained on other pages.
+      const existingWidget = widgetZone.querySelector('obe-widget');
+      if (existingWidget) {
+        existingWidget.remove();
       }
 
       if (!page.validateWidgetZone(widgetZone)) break;


### PR DESCRIPTION
While doing QA for the LinkedIn widget, I found the following issue:

- Visit your personal profile and open the widget
- Navigate to another profile (step 1 below)
- Navigate to your personal profile again using the navbar dropdown under your profile picture (step 2 below)

![CleanShot 2023-05-26 at 16 30 50@2x](https://github.com/orbit-love/orbit-browser-extension/assets/2587348/52f199b1-e144-471f-9485-516e0b98a752)

What I was seeing is that on my personal profile, the widget showed the information from the other profile.

The fix is to remove any existing widgets and recreate new ones, rather than skipping the operation entirely (which we used to do).