### PR TITLE
Fix issues with Twitter profiles and GitHub discussions

### DIFF
--- a/src/components/githubDiscussionButton.js
+++ b/src/components/githubDiscussionButton.js
@@ -1,0 +1,29 @@
+import { LitElement, html, unsafeCSS } from "lit";
+
+import { unsafeSVG } from "lit/directives/unsafe-svg.js";
+import { customElement } from "lit/decorators.js";
+
+import tailwindStylesheet from "bundle-text:../styles/tailwind.global.css";
+import orbitLogo from "bundle-text:../icons/orbit-logo.svg";
+
+@customElement("obe-github-discussion-button")
+class GitHubDiscussionButton extends LitElement {
+  static styles = [unsafeCSS(tailwindStylesheet)];
+
+  render() {
+    return html`
+      <div>
+        <button
+          type="button"
+          class="inline-block rounded px-[4px] py-[8px] text-[#656d76] hover:bg-[#d0d7de52]"
+          id="menu-button"
+          aria-expanded="true"
+          aria-haspopup="true"
+        >
+          <span class="sr-only">Open Orbit widget</span>
+          ${unsafeSVG(orbitLogo)}
+        </button>
+      </div>
+    `;
+  }
+}

--- a/src/components/githubIssueOrPullRequestButton.js
+++ b/src/components/githubIssueOrPullRequestButton.js
@@ -6,8 +6,8 @@ import { customElement } from "lit/decorators.js";
 import tailwindStylesheet from "bundle-text:../styles/tailwind.global.css";
 import orbitLogo from "bundle-text:../icons/orbit-logo.svg";
 
-@customElement("obe-github-button")
-class GitHubButton extends LitElement {
+@customElement("obe-github-issue-or-pull-request-button")
+class GitHubIssueOrPullRequestButton extends LitElement {
   static styles = [unsafeCSS(tailwindStylesheet)];
 
   render() {

--- a/src/pages/githubDiscussionPage.js
+++ b/src/pages/githubDiscussionPage.js
@@ -1,6 +1,8 @@
 import Page from "./page";
 
 export default class GitHubDiscussionPage extends Page {
+  getPlatform() { return 'github' }
+
   detect() {
     const pageRegex = /.*\/.*\/discussions?\/.*/;
     return pageRegex.test(window.location.pathname);

--- a/src/pages/githubDiscussionPage.js
+++ b/src/pages/githubDiscussionPage.js
@@ -25,6 +25,8 @@ export default class GitHubDiscussionPage extends Page {
   }
 
   findInsertionPoint(comment) {
-    return comment.querySelector(".timeline-comment-actions");
+    return comment.querySelector(".timeline-comment-actions").children[0];
   }
+
+  getButtonElementName() { return 'obe-github-discussion-button' }
 }

--- a/src/pages/githubIssueOrPullRequestPage.js
+++ b/src/pages/githubIssueOrPullRequestPage.js
@@ -1,6 +1,8 @@
 import Page from "./page";
 
 export default class GitHubIssueOrPullRequestPage extends Page {
+  getPlatform() { return 'github' }
+
   detect() {
     const issuePageRegex = /.*\/.*\/issues?\/.*/;
     const pullRequestPageRegex = /.*\/.*\/pulls?\/.*/;

--- a/src/pages/githubIssueOrPullRequestPage.js
+++ b/src/pages/githubIssueOrPullRequestPage.js
@@ -27,4 +27,6 @@ export default class GitHubIssueOrPullRequestPage extends Page {
   findInsertionPoint(comment) {
     return comment.querySelector(".timeline-comment-actions");
   }
+
+  getButtonElementName() { return 'obe-github-issue-or-pull-request-button' }
 }

--- a/src/pages/gmailEmailThreadPage.js
+++ b/src/pages/gmailEmailThreadPage.js
@@ -1,6 +1,8 @@
 import Page from "./page";
 
 export default class GmailEmailThreadPage extends Page {
+  getPlatform() { return 'gmail' }
+
   detect() {
     const topLevelPageRegex =
       /(#inbox|#starred|#snoozed|#sent|#scheduled|#drafts|#imp|#all|#spam|#trash)\/\w+/;

--- a/src/pages/linkedinProfilePage.js
+++ b/src/pages/linkedinProfilePage.js
@@ -1,6 +1,8 @@
 import Page from "./page";
 
 export default class LinkedinProfilePage extends Page {
+  getPlatform() { return 'linkedin' }
+
   detect() {
     const pathname = window.location.pathname;
     return pathname.startsWith("/in/");

--- a/src/pages/page.js
+++ b/src/pages/page.js
@@ -1,6 +1,7 @@
 export default class Page {
   /**
-   * Check if we are currently on this type of page
+   * Returns the standard name of the platform this page belongs to, e.g. "github", "twitter", "gmail".
+   * We use a method rather than internal state to be consistant with this class being an interface.
    *
    * @returns {String}
    */

--- a/src/pages/page.js
+++ b/src/pages/page.js
@@ -47,4 +47,10 @@ export default class Page {
    * @returns {Element|null}
    */
   findInsertionPoint(widgetZone) {}
+
+  /**
+   * Returns the name of the CustomElement of the widget button.
+   * If not defined, `obe-{platform}-button` will be used.
+   */
+  getButtonElementName() {}
 }

--- a/src/pages/page.js
+++ b/src/pages/page.js
@@ -2,6 +2,13 @@ export default class Page {
   /**
    * Check if we are currently on this type of page
    *
+   * @returns {String}
+   */
+  getPlatform() {}
+
+  /**
+   * Check if we are currently on this type of page
+   *
    * @returns {Boolean}
    */
   detect() {}
@@ -50,7 +57,9 @@ export default class Page {
 
   /**
    * Returns the name of the CustomElement of the widget button.
-   * If not defined, `obe-{platform}-button` will be used.
+   * Returns `obe-{platform}-button` by default.
+   *
+   * @returns {String}
    */
-  getButtonElementName() {}
+  getButtonElementName() { return `obe-${this.getPlatform()}-button`; }
 }

--- a/src/pages/twitterProfilePage.js
+++ b/src/pages/twitterProfilePage.js
@@ -1,6 +1,8 @@
 import Page from "./page";
 
 export default class TwitterProfilePage extends Page {
+  getPlatform() { return 'twitter' }
+
   detect() {
     /**
      * Since Twitter doesn't have a specific URL pattern for profile

--- a/src/pages/twitterProfilePage.js
+++ b/src/pages/twitterProfilePage.js
@@ -4,10 +4,10 @@ export default class TwitterProfilePage extends Page {
   detect() {
     /**
      * Since Twitter doesn't have a specific URL pattern for profile
-     * pages, we look for a header photo instead. Conveniently, they always
-     * seem to link to "/<username>/header_photo"
+     * pages, we look for a main profile picture instead. Conveniently, they always
+     * seem to link to "/<username>/photo"
      */
-    return !!document.querySelector('a[href$="/header_photo"]');
+    return !!document.querySelector('a[href$="/photo"]');
   }
 
   findWidgetZones() {
@@ -50,14 +50,14 @@ export default class TwitterProfilePage extends Page {
 
   findUsername(main) {
     /**
-     * The headerPhoto element here is a link surrounding the, well, header photo,
-     * which links to "/<username>/header_photo"
+     * The headerProfilePhoto element here is a link surrounding the, well, header profile photo,
+     * which links to "/<username>/photo"
      */
-    const headerPhoto = main.querySelector('a[href$="/header_photo"]');
+    const headerProfilePhoto = main.querySelector('a[href$="/photo"]');
 
-    if (!headerPhoto) { return }
+    if (!headerProfilePhoto) { return }
 
-    return headerPhoto.getAttribute('href').split('/')[1];
+    return headerProfilePhoto.getAttribute('href').split('/')[1];
   }
 
   findInsertionPoint(main) {

--- a/src/pages/twitterProfilePage.test.js
+++ b/src/pages/twitterProfilePage.test.js
@@ -8,9 +8,9 @@ describe("TwitterProfilePage", () => {
   });
 
   describe("#detect", () => {
-    it("detects header photos", () => {
+    it("detects header profile photos", () => {
       const headerPhoto = document.createElement("a");
-      headerPhoto.setAttribute('href', '/OrbitModel/header_photo');
+      headerPhoto.setAttribute('href', '/OrbitModel/photo');
       document.body.appendChild(headerPhoto);
       expect(page.detect()).toBe(true);
       document.body.removeChild(headerPhoto);

--- a/src/widget/githubEntrypoint.js
+++ b/src/widget/githubEntrypoint.js
@@ -20,7 +20,7 @@ const initializeWidget = () => {
   const page = orchestrator.detectPage(pages);
   if (!page) return;
 
-  orchestrator.addWidgetElements(page, "github");
+  orchestrator.addWidgetElements(page);
 };
 
 document.addEventListener("DOMContentLoaded", initializeWidget);

--- a/src/widget/gmailEntrypoint.js
+++ b/src/widget/gmailEntrypoint.js
@@ -23,7 +23,7 @@ const initializeWidget = () => {
   const page = orchestrator.detectPage(pages);
   if (!page) return;
 
-  orchestrator.addWidgetElements(page, "gmail");
+  orchestrator.addWidgetElements(page);
 
   // Element id=:1 is the "thread view" on thread pages (and also the "inbox view" for inbox pages)
   const threadElement = document.querySelector('#\\:1');
@@ -33,7 +33,7 @@ const initializeWidget = () => {
   // On changes to the "thread view", rerun the orchestrator again. This is so that we can
   // track when the user expands an email, and add the widget at that time.
   observer = new MutationObserver((_mutationList, _observer) => {
-    orchestrator.addWidgetElements(page, "gmail");
+    orchestrator.addWidgetElements(page);
   });
 
   observer.observe(threadElement, {

--- a/src/widget/linkedinEntrypoint.js
+++ b/src/widget/linkedinEntrypoint.js
@@ -14,7 +14,7 @@ const initializeWidget = () => {
   const page = orchestrator.detectPage(pages);
   if (!page) return;
 
-  orchestrator.addWidgetElements(page, "linkedin");
+  orchestrator.addWidgetElements(page);
 }
 
 async function setupObserver() {
@@ -22,7 +22,7 @@ async function setupObserver() {
 
   if (!titleElement) { return }
 
-  const observer = new MutationObserver((mutationList, _observer) => {
+  const observer = new MutationObserver((_mutationList, _observer) => {
     initializeWidget();
   });
   

--- a/src/widget/twitterEntrypoint.js
+++ b/src/widget/twitterEntrypoint.js
@@ -35,7 +35,7 @@ async function setupObserver() {
 
       // Adding a small timeout so that page transitions can complete (most of the time),
       // which helps with detecting profile pages.
-      setTimeout(initializeWidget, 250);
+      setTimeout(initializeWidget, 500);
     });
   });
   

--- a/src/widget/twitterEntrypoint.js
+++ b/src/widget/twitterEntrypoint.js
@@ -33,7 +33,9 @@ async function setupObserver() {
 
       if (newTitle === undefined || newTitle.indexOf('@') === -1) { return }
 
-      initializeWidget();
+      // Adding a small timeout so that page transitions can complete (most of the time),
+      // which helps with detecting profile pages.
+      setTimeout(initializeWidget, 250);
     });
   });
   

--- a/src/widget/twitterEntrypoint.js
+++ b/src/widget/twitterEntrypoint.js
@@ -14,7 +14,7 @@ const initializeWidget = () => {
   const page = orchestrator.detectPage(pages);
   if (!page) return;
 
-  orchestrator.addWidgetElements(page, "twitter");
+  orchestrator.addWidgetElements(page);
 }
 
 async function setupObserver() {

--- a/src/widget/widgetOrchestrator.js
+++ b/src/widget/widgetOrchestrator.js
@@ -22,9 +22,9 @@ export default class WidgetOrchestrator {
    * Inserts the widget for each of the zones on given page
    *
    * @param {Page} page the page to insert widget on
-   * @param {string} platform the site we're on, used as a key for naming HTML elements
    */
-  addWidgetElements(page, platform) {
+  addWidgetElements(page) {
+    const platform = page.getPlatform();
     const widgetZones = page.findWidgetZones();
 
     for (const widgetZone of widgetZones) {
@@ -54,7 +54,7 @@ export default class WidgetOrchestrator {
       if (!insertionPoint) continue;
 
       const widgetElement = this.addWidgetElement(username, platform);
-      this.addOrbitButton(widgetElement, platform, page);
+      this.addOrbitButton(widgetElement, page);
       this.addAdditionalDataElements(widgetElement, platform);
 
       insertionPoint.insertBefore(widgetElement, insertionPoint.children[0]);
@@ -83,13 +83,12 @@ export default class WidgetOrchestrator {
    * Adds the orbit button to a given widget element
    *
    * @param {Element} widgetElement element to which we append the button
-   * @param {string} platform the site we're on, used as a key for naming HTML elements
+   * @param {Page} page the current page
    *
    * @returns {Element} the created button
    */
-  addOrbitButton(widgetElement, platform, page) {
-    const buttonElementName =
-      page.getButtonElementName() || `obe-${platform}-button`;
+  addOrbitButton(widgetElement, page) {
+    const buttonElementName = page.getButtonElementName();
     if (!!widgetElement.querySelector(buttonElementName)) return;
 
     const buttonElement = window.document.createElement(buttonElementName);

--- a/src/widget/widgetOrchestrator.js
+++ b/src/widget/widgetOrchestrator.js
@@ -1,6 +1,7 @@
 import { Page } from "../pages/page";
 import "../components/widget";
-import "../components/githubButton";
+import "../components/githubIssueOrPullRequestButton";
+import "../components/githubDiscussionButton";
 import "../components/twitterButton";
 import "../components/linkedinButton";
 import "../components/gmailButton";
@@ -24,20 +25,19 @@ export default class WidgetOrchestrator {
    * @param {string} platform the site we're on, used as a key for naming HTML elements
    */
   addWidgetElements(page, platform) {
-
     const widgetZones = page.findWidgetZones();
 
     for (const widgetZone of widgetZones) {
       // If a widget already exists for this widgetZone, remove it.
       // This fixes an issue with SPAs like LinkedIn, where the first widget
       // that was injected remained on other pages.
-      const existingWidget = widgetZone.querySelector('obe-widget');
+      const existingWidget = widgetZone.querySelector("obe-widget");
       if (existingWidget) {
         // TODO: there is an infinite loop happening with Gmail:
         // We’re triggering this method when any element is added to the page, but
         // we’re also adding an element with this method. Friday-evening-quick-workaround is
         // to opt-out of this behavior for now, so that it doesn’t block internal testing.
-        if (platform === 'gmail') {
+        if (platform === "gmail") {
           continue;
         }
         existingWidget.remove();
@@ -54,7 +54,7 @@ export default class WidgetOrchestrator {
       if (!insertionPoint) continue;
 
       const widgetElement = this.addWidgetElement(username, platform);
-      this.addOrbitButton(widgetElement, platform);
+      this.addOrbitButton(widgetElement, platform, page);
       this.addAdditionalDataElements(widgetElement, platform);
 
       insertionPoint.insertBefore(widgetElement, insertionPoint.children[0]);
@@ -87,12 +87,12 @@ export default class WidgetOrchestrator {
    *
    * @returns {Element} the created button
    */
-  addOrbitButton(widgetElement, platform) {
-    if (!!widgetElement.querySelector(`obe-${platform}-button`)) return;
+  addOrbitButton(widgetElement, platform, page) {
+    const buttonElementName =
+      page.getButtonElementName() || `obe-${platform}-button`;
+    if (!!widgetElement.querySelector(buttonElementName)) return;
 
-    const buttonElement = window.document.createElement(
-      `obe-${platform}-button`
-    );
+    const buttonElement = window.document.createElement(buttonElementName);
 
     buttonElement.setAttribute("slot", "button");
 

--- a/src/widget/widgetOrchestrator.test.js
+++ b/src/widget/widgetOrchestrator.test.js
@@ -137,10 +137,15 @@ describe("addWidgetElement", () => {
 });
 
 describe("#addOrbitButton", () => {
+  let page;
+  beforeEach(() => {
+    page = new Page();
+  });
+
   it("adds button element if none exist", () => {
     const widget = document.createElement("div");
     document.body.appendChild(widget);
-    const button = orchestrator.addOrbitButton(widget, "test");
+    const button = orchestrator.addOrbitButton(widget, "test", page);
 
     expect(widget.children.item(0)).toEqual(button);
     expect(widget.children.length).toEqual(1);
@@ -155,11 +160,29 @@ describe("#addOrbitButton", () => {
     const button = document.createElement("obe-test-button");
     widget.appendChild(button);
 
-    orchestrator.addOrbitButton(widget, "test");
+    orchestrator.addOrbitButton(widget, "test", page);
 
     expect(widget.children.item(0)).toEqual(button);
     expect(widget.children.length).toEqual(1);
     expect(button.tagName).toEqual("OBE-TEST-BUTTON");
+  });
+
+  it("uses button element name from page if it is defined in #getButtonElementName", () => {
+    jest
+    .spyOn(page, "getButtonElementName")
+    .mockImplementation(() =>
+      'obe-test-profile-button'
+    );
+
+    const widget = document.createElement("div");
+    document.body.appendChild(widget);
+
+    const button = orchestrator.addOrbitButton(widget, "test", page);
+
+    expect(widget.children.item(0)).toEqual(button);
+    expect(widget.children.length).toEqual(1);
+    expect(button.getAttribute("slot")).toBe("button");
+    expect(button.tagName).toEqual("OBE-TEST-PROFILE-BUTTON");
   });
 });
 

--- a/src/widget/widgetOrchestrator.test.js
+++ b/src/widget/widgetOrchestrator.test.js
@@ -140,12 +140,13 @@ describe("#addOrbitButton", () => {
   let page;
   beforeEach(() => {
     page = new Page();
+    jest.spyOn(page, "getPlatform").mockReturnValue('test');
   });
 
   it("adds button element if none exist", () => {
     const widget = document.createElement("div");
     document.body.appendChild(widget);
-    const button = orchestrator.addOrbitButton(widget, "test", page);
+    const button = orchestrator.addOrbitButton(widget, page);
 
     expect(widget.children.item(0)).toEqual(button);
     expect(widget.children.length).toEqual(1);
@@ -160,7 +161,7 @@ describe("#addOrbitButton", () => {
     const button = document.createElement("obe-test-button");
     widget.appendChild(button);
 
-    orchestrator.addOrbitButton(widget, "test", page);
+    orchestrator.addOrbitButton(widget, page);
 
     expect(widget.children.item(0)).toEqual(button);
     expect(widget.children.length).toEqual(1);
@@ -177,7 +178,7 @@ describe("#addOrbitButton", () => {
     const widget = document.createElement("div");
     document.body.appendChild(widget);
 
-    const button = orchestrator.addOrbitButton(widget, "test", page);
+    const button = orchestrator.addOrbitButton(widget, page);
 
     expect(widget.children.item(0)).toEqual(button);
     expect(widget.children.length).toEqual(1);


### PR DESCRIPTION
This PR fixes three issues with the widget:

**GitHub discussion button layout and appearance**

| Before | After |
|--------|--------|
| <img width="185" alt="CleanShot 2023-05-31 at 11 21 52@2x" src="https://github.com/orbit-love/orbit-browser-extension/assets/2587348/55ca6281-a51c-470e-8961-85e0adc6c8db"> | <img width="208" alt="CleanShot 2023-05-31 at 11 21 18@2x" src="https://github.com/orbit-love/orbit-browser-extension/assets/2587348/1183b794-7873-4588-92b0-8510e9b3dee2"> | 

**Twitter profiles without banner pictures would not show the widget**

You can test the before/after on e.g. [this profile](https://twitter.com/_byroot).

**Navigating from the homepage to a profile via the DM drawer would not show the widget**

This has been “fixed” in most cases by adding a small timeout in `twitterEntrypoint.js`. The cause is that the page is not fully loaded by the time the title changes, and so we don’t detect the page as a profile page.

You can test the before/after as shown below:

![CleanShot 2023-05-31 at 11 23 55@2x](https://github.com/orbit-love/orbit-browser-extension/assets/2587348/5cef8b30-7ebe-42dc-a7b6-cb99fbf8be80)
