### PR TITLE
[Refactor] Better mechanism for Gmail collapsed emails using eventListeners

### DIFF
--- a/src/widget/gmailEntrypoint.js
+++ b/src/widget/gmailEntrypoint.js
@@ -5,16 +5,7 @@ import WidgetOrchestrator from "./widgetOrchestrator";
 
 import GmailEmailThreadPage from "../pages/gmailEmailThreadPage";
 
-/**
- * We keep track of the mutation observer so that we can disconnect it
- * when the user navigates away from an email thread page. This is to avoid
- * incurring an (admittedly small) performance penalty when browsing around GMail.
- */
-let observer = new MutationObserver(() => {});
-
 const initializeWidget = () => {
-  // Start by disconnecting the observer
-  if (observer) { observer.disconnect(); }
 
   const pages = [ new GmailEmailThreadPage() ];
 
@@ -30,24 +21,46 @@ const initializeWidget = () => {
 
   if (!threadElement) { return }
 
-  // On changes to the "thread view", rerun the orchestrator again. This is so that we can
-  // track when the user expands an email, and add the widget at that time.
-  observer = new MutationObserver((_mutationList, _observer) => {
-    orchestrator.addWidgetElements(page);
-  });
+  /**
+   * GMail threads have two kinds of emails: "collapsed" and "expanded". We only want to show the widget on
+   * expanded emails. Clicking on a collapsed email expands it, but critically it does so by creating a new DOM node;
+   * meaning we can’t preemptively attach widgets to all expanded emails in one go -- only those which are expanded
+   * when the page first loads.
+   * To work around this, we listen to the click event on all collapsed emails: on click, we simply rerun the
+   * widget orchestrator, which will create (or replace) all the widgets -- most importantly, it will create the widget
+   * on the email that the user clicked on.
+   */
+  const addEventListenersToCollapsedEmailElements = () => {
+    const collapsedEmailElements = threadElement.querySelectorAll("[role='listitem']:not([aria-expanded='true'])")
 
-  observer.observe(threadElement, {
-    subtree: true,
-    childList: true
-  });
+    for (const collapsedEmailElement of collapsedEmailElements) {
+      collapsedEmailElement.addEventListener('click', function handleClickOnCollapsedEmail() {
+        this.removeEventListener('click', handleClickOnCollapsedEmail)
+        orchestrator.addWidgetElements(page);
+      })
+    }
+  }
 
-  return observer;
+  addEventListenersToCollapsedEmailElements();
+
+  /**
+   * For long thread, GMail "hides" long groups of email behind a button (indicating how many emails are hidden).
+   * When clicking on the button, new collapsed emails are created in the DOM, and we can run the method described
+   * above again.
+   */
+  const expandThreadButtonElement = threadElement.querySelector("span[role='button'][aria-expanded='false']")
+
+  if (!expandThreadButtonElement) { return }
+  expandThreadButtonElement.addEventListener('click', function handleClickOnExpandThread() {
+    // Note: we need a short timeout here so that the collapsed emails are created in the DOM
+    setTimeout(addEventListenersToCollapsedEmailElements, 100);
+  });
 }
 
 // I could not find any event fired after the page has finished loading.
 // As a stopgap, we listen for DOMContentLoaded (fired when the loading screen appears)
 // and wait 2s more to be safe.
-document.addEventListener("DOMContentLoaded", () => setTimeout(() => observer = initializeWidget(), 2000));
+document.addEventListener("DOMContentLoaded", () => setTimeout(initializeWidget, 2000));
 
 // Navigating around GMail changes the hash
-window.addEventListener('hashchange', () => { observer = initializeWidget() });
+window.addEventListener('hashchange', initializeWidget);

--- a/src/widget/widgetOrchestrator.js
+++ b/src/widget/widgetOrchestrator.js
@@ -33,13 +33,6 @@ export default class WidgetOrchestrator {
       // that was injected remained on other pages.
       const existingWidget = widgetZone.querySelector("obe-widget");
       if (existingWidget) {
-        // TODO: there is an infinite loop happening with Gmail:
-        // We’re triggering this method when any element is added to the page, but
-        // we’re also adding an element with this method. Friday-evening-quick-workaround is
-        // to opt-out of this behavior for now, so that it doesn’t block internal testing.
-        if (platform === "gmail") {
-          continue;
-        }
         existingWidget.remove();
       }
 


### PR DESCRIPTION
This PR addresses a workaround introduced last Friday and implements a more lightweight solution to the issue of collapsed emails in GMail.

Instead of using a mutation observer on main element of the page (which is heavy handed and introduced a lot of calls to the widget orchestrator, most of which were not used), it adds event listeners on collapsed emails and the “show more button” to achieve the same goals.

Ultimately this allows us to remove a GMail specificity in `widgetOrchestrator`.

To test, try the extension in GMail and:

- Make sure that already-expanded emails show the widget
- Expand a collapsed email, and make sure that it shows the widget
- If you have a long (10+?) thread, click the show more button (see below) and expand an email below that, it should also show the widget

<img width="68" alt="CleanShot 2023-05-31 at 15 02 43@2x" src="https://github.com/orbit-love/orbit-browser-extension/assets/2587348/8875b552-6d26-4d06-8802-ece2b62d94b8">

(Note to self: I need to rebase this PR on #51 before merging as `addWidgetElements` signature changed)