### PR TITLE
Better handling for OAuth failure

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -220,7 +220,15 @@ document.addEventListener("alpine:init", () => {
 
             return this.getOAuthToken(parsed.code, codeVerifier);
           } else {
-            // TODO: Verify failure routes from OAuth
+            // How to reach this block:
+            // - Revoke any existing access tokens (ie, sign out)
+            // - Click sign in
+            // - In the popup, click “Orbit Account Settings” link at bottom of page
+            // - Go back
+            // - Click cancel
+            this.showLogin = true;
+            this.errorMessage = "Failed to authenticate, please try again.";
+
             console.error(
               "launchWebAuthFlow login failed. Is your redirect URL (" +
                 chrome.identity.getRedirectURL("oauth2") +


### PR DESCRIPTION
Uncaught edge case for authentication -
- Revoke any existing access tokens (ie, sign out)
- Click sign in
- In the popup, click “Orbit Account Settings” link at bottom of page
- Go back
- Click cancel
“This site cannot be reached” error in app, “launchWebAuthFlow login failed” error in console on extension
Catches the exception, handles it nicely in extension. Still fails in app 😵‍💫 

https://github.com/orbit-love/orbit-browser-extension/assets/45462299/d8bb25e9-53f2-4c84-bb1e-4f534a3a3ab1

Kind of weird edge case, not sure how common it will be