### PR TITLE
Use `/api/v1` URL prefix for API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run `yarn test` to start the test suite, or `yarn test:watch` to run them contin
 
 To reload the extension after some changes, open [`chrome://extensions`](chrome://extensions) and click on the “reload” button for the Orbit one.
 
-To use the local API instead of the prod one, change `ORBIT_API_ROOT_URL` in `orbit-helper.js` to your ngrok tunnel address.
+To use the local API instead of the prod one, change `ORBIT_ROOT_URL` in `orbit-helper.js` to your ngrok tunnel address.
 
 ## Deployment
 

--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
 import "chrome-extension-async";
-import { ORBIT_API_ROOT_URL, OAUTH_CLIENT_ID } from "./constants";
+import { ORBIT_ROOT_URL, ORBIT_API_ROOT_URL, OAUTH_CLIENT_ID } from "./constants";
 import { configureRequest, getOrbitCredentials } from "./oauth-helpers";
 
 // When clicking on the Orbit extension button, open the options page
@@ -97,7 +97,7 @@ const loadWorkspaces = async ({ accessToken, apiKey }) => {
  */
 const getOAuthToken = async ({ oAuthCode, codeVerifier }) => {
   try {
-    let authUrl = new URL(`${ORBIT_API_ROOT_URL}/oauth/token`);
+    let authUrl = new URL(`${ORBIT_ROOT_URL}/oauth/token`);
 
     let params = new URLSearchParams({
       client_id: OAUTH_CLIENT_ID,
@@ -128,7 +128,7 @@ const getOAuthToken = async ({ oAuthCode, codeVerifier }) => {
  */
 const refreshOAuthToken = async ({ refreshToken }) => {
   try {
-    const url = new URL(`${ORBIT_API_ROOT_URL}/oauth/token`);
+    const url = new URL(`${ORBIT_ROOT_URL}/oauth/token`);
     let params = new URLSearchParams({
       grant_type: "refresh_token",
       client_id: OAUTH_CLIENT_ID,

--- a/src/components/tag.js
+++ b/src/components/tag.js
@@ -3,7 +3,7 @@ import { customElement } from "lit/decorators.js";
 
 import tailwindStylesheet from "bundle-text:../styles/tailwind.global.css";
 
-import { ORBIT_API_ROOT_URL } from "../constants";
+import { ORBIT_ROOT_URL } from "../constants";
 
 @customElement("obe-tag")
 class Tag extends LitElement {
@@ -20,7 +20,7 @@ class Tag extends LitElement {
     return html`
       <li>
         <a
-          href="${ORBIT_API_ROOT_URL}/${this
+          href="${ORBIT_ROOT_URL}/${this
             .workspace}/members?tags_contains_any_of[]=${this.tag}"
           title="View all members tagged ${this.tag} in Orbit"
           target="_blank"

--- a/src/components/widget.js
+++ b/src/components/widget.js
@@ -9,7 +9,7 @@ import "./additionalData";
 import tailwindStylesheet from "bundle-text:../styles/tailwind.global.css";
 import iconCustomer from "bundle-text:../icons/icon-customer.svg";
 import iconOrbitLevel from "bundle-text:../icons/icon-orbit-level.svg";
-import { ORBIT_API_ROOT_URL } from "../constants";
+import { ORBIT_ROOT_URL } from "../constants";
 import {
   buildMemberData,
   formatDate,
@@ -364,7 +364,7 @@ class Widget extends LitElement {
         <a
           target="_blank"
           rel="noreferrer noopener"
-          href="${ORBIT_API_ROOT_URL}/${this.workspace}/members/${this.member
+          href="${ORBIT_ROOT_URL}/${this.workspace}/members/${this.member
             .slug}"
           class="block py-5 px-4 w-full text-left text-[#6C4DF6] font-semibold truncate rounded-b-md hover:bg-gray-100 focus:bg-gray-100"
         >

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,12 @@
 /**
- * The URL of the API root.
- * To be changed to `https://orbit.eu.ngrok.io` for local development.
+ * The URL of the Orbit app.
  */
-export const ORBIT_API_ROOT_URL = "https://app.orbit.love";
+export const ORBIT_ROOT_URL = "https://app.orbit.love";
+
+/**
+ * The URL of the API root.
+ */
+export const ORBIT_API_ROOT_URL = `${ORBIT_ROOT_URL}/api/v1`;
 
 /**
  * Client ID of the OAUTH application generated in Orbit app

--- a/src/github/orbit-action.js
+++ b/src/github/orbit-action.js
@@ -8,7 +8,7 @@ import {
   createOrbitMetrics,
   createTagList,
 } from "./dom-helpers";
-import { ORBIT_API_ROOT_URL } from "../constants";
+import { ORBIT_ROOT_URL } from "../constants";
 import { getThreshold } from "../helpers/widget-helper";
 
 /**
@@ -321,7 +321,7 @@ export async function createOrbitDetailsElement(
     detailsMenuLinkProfile.setAttribute("role", "menuitem");
     detailsMenuLinkProfile.setAttribute(
       "href",
-      `${ORBIT_API_ROOT_URL}/${normalizedWorkspace}/members/${$slug}`
+      `${ORBIT_ROOT_URL}/${normalizedWorkspace}/members/${$slug}`
     );
     detailsMenuLinkProfile.setAttribute("target", "_blank");
     detailsMenuLinkProfile.setAttribute("rel", "noopener");
@@ -384,7 +384,7 @@ export async function createOrbitDetailsElement(
     if (success) {
       event.target.setAttribute(
         "href",
-        `${ORBIT_API_ROOT_URL}/${normalizedWorkspace}/members/${gitHubUsername}`
+        `${ORBIT_ROOT_URL}/${normalizedWorkspace}/members/${gitHubUsername}`
       );
       event.target.setAttribute("target", "_blank");
       event.target.setAttribute("rel", "noopener");

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,9 +1,8 @@
 import "chrome-extension-async";
 import Alpine from "alpinejs";
 
-import { ORBIT_API_ROOT_URL, OAUTH_CLIENT_ID } from "../constants";
+import { ORBIT_ROOT_URL, OAUTH_CLIENT_ID } from "../constants";
 import {
-  configureRequest,
   generateCodeChallenge,
   generateCodeVerifier,
   parseQueryParams as parseQueryParams,
@@ -199,7 +198,7 @@ document.addEventListener("alpine:init", () => {
       let codeVerifier = generateCodeVerifier();
       let codeChallenge = await generateCodeChallenge(codeVerifier);
 
-      let authUrl = new URL(`${ORBIT_API_ROOT_URL}/oauth/authorize`);
+      let authUrl = new URL(`${ORBIT_ROOT_URL}/oauth/authorize`);
 
       let params = new URLSearchParams({
         client_id: OAUTH_CLIENT_ID,


### PR DESCRIPTION
While the Orbit API understands calls to `app.orbit.love/<path>` as API calls provided the `Accepts` header is set to `application/json`, using explicit `app.orbit.love/api/v1/<path>` calls is more appropriate.