### PR TITLE
Fix: better behavior when Org website is missing/Avatar URL is missing (or not found)

### DIFF
--- a/src/components/avatar.js
+++ b/src/components/avatar.js
@@ -1,0 +1,50 @@
+import { LitElement, html, unsafeCSS, nothing } from "lit";
+import { customElement } from "lit/decorators.js";
+
+import tailwindStylesheet from "bundle-text:../styles/tailwind.global.css";
+
+@customElement("obe-avatar")
+class Avatar extends LitElement {
+  static get properties() {
+    return {
+      avatarUrl: { attribute: "avatar-url", type: String, },
+      fallback: { type: String },
+      isAvatarUrlValid: { state: true, type: Boolean },
+    };
+  }
+
+  async connectedCallback() {
+    super.connectedCallback();
+
+    this.isAvatarUrlValid = await this.checkAvatarUrlValidity();
+  }
+
+  async checkAvatarUrlValidity() {
+    if (!this.avatarUrl) { return false }
+    const response = await fetch(this.avatarUrl);
+    return response.ok;
+  }
+
+  static styles = [unsafeCSS(tailwindStylesheet)];
+
+  render() {
+    if (this.isAvatarUrlValid === undefined) {
+      return nothing;
+    }
+    if (!this.isAvatarUrlValid) {
+      return html`<div
+        class="flex justify-center items-center w-14 h-14 bg-gradient-to-br from-purple-400 to-blue-500 rounded-full"
+      >
+        <span class="text-white font-bold text-xl" role="img" alt=""
+          >${this.fallback}</span
+        >
+      </div>`;
+    } else {
+      return html`<img
+        alt=""
+        class="w-14 h-14 rounded-full"
+        src="${this.avatarUrl}"
+      />`;
+    }
+  }
+}

--- a/src/components/avatar.test.js
+++ b/src/components/avatar.test.js
@@ -1,0 +1,46 @@
+import "./avatar";
+
+describe("obe-avatar", () => {
+  let element;
+
+  afterEach(() => {
+    document.body.removeChild(element);
+  });
+
+  describe("avatarUrl is valid", () => {
+    beforeEach(() => {
+      global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+
+      element = document.createElement("obe-avatar");
+      element.setAttribute("avatar-url", "https://example.com/avatar.jpg");
+      element.setAttribute("fallback", "SR");
+      document.body.appendChild(element);
+    });
+
+    it("displays an image", async () => {
+      const image = element.shadowRoot.querySelector("img");
+      const placeholder = element.shadowRoot.querySelector("div[role='img']");
+      expect(placeholder).toBeNull();
+      expect(image).toBeTruthy();
+      expect(image.getAttribute("src")).toBe("https://example.com/avatar.jpg");
+    });
+  });
+
+  describe("avatarUrl is invalid", () => {
+    beforeEach(() => {
+      global.fetch = jest.fn(() => Promise.resolve({ ok: false }));
+
+      element = document.createElement("obe-avatar");
+      element.setAttribute("avatar-url", "https://example.com/avatar.jpg");
+      element.setAttribute("fallback", "SR");
+      document.body.appendChild(element);
+    });
+
+    it("displays a fallback placeholder", async () => {
+      const image = element.shadowRoot.querySelector("img");
+      const placeholder = element.shadowRoot.querySelector("div span[role='img']");
+      expect(image).toBeNull();
+      expect(placeholder.innerHTML).toMatch("SR");
+    });
+  });
+});

--- a/src/components/widget.js
+++ b/src/components/widget.js
@@ -179,17 +179,21 @@ class Widget extends LitElement {
                       src="${this.member.organization.logo_url}"
                     />`}
                     <!-- If organisation doesn't include a protocol (ie https://), add one so it's treated as absolute -->
-                    <a
-                      href="${this.member.organization.website.match(
-                        /https?:\/\//
-                      )
-                        ? this.member.organization.website
-                        : `https://${this.member.organization.website}`}"
-                      target="_blank"
-                      rel="noreferrer"
-                      class="mr-2 text-sm font-semibold text-[#6C4DF6] hover:underline"
-                      >${this.member.organization.name}</a
-                    >
+                    ${this.member.organization.website
+                      ? html`<a
+                          href="${this.member.organization.website.match(
+                            /https?:\/\//
+                          )
+                            ? this.member.organization.website
+                            : `https://${this.member.organization.website}`}"
+                          target="_blank"
+                          rel="noreferrer"
+                          class="mr-2 text-sm font-semibold text-[#6C4DF6] hover:underline"
+                          >${this.member.organization.name}</a
+                        >`
+                      : html`<span class="mr-2 text-sm font-semibold text-gray-500"
+                          >${this.member.organization.name}</span
+                        >`}
                     ${this.member.organization.lifecycle_stage === "customer"
                       ? html`<span class="sr-only">Customer</span>
                           <span aria-hidden="true"

--- a/src/components/widget.js
+++ b/src/components/widget.js
@@ -1,6 +1,7 @@
 import { LitElement, html, css, nothing, unsafeCSS } from "lit";
 import { customElement } from "lit/decorators.js";
 import { unsafeSVG } from "lit/directives/unsafe-svg.js";
+import "./avatar";
 import "./pill";
 import "./tag";
 import "./identity";
@@ -147,13 +148,7 @@ class Widget extends LitElement {
     return html`
       <div class="px-4 py-5">
         <section class="flex gap-4">
-          <!-- Avatar -->
-          ${this.member.avatarUrl &&
-          html`<img
-            alt=""
-            class="w-14 h-14 rounded-full"
-            src="${this.member.avatarUrl}"
-          />`}
+          <obe-avatar avatar-url="${this.member.avatarUrl}" fallback="${this._getMemberInitials()}"></obe-avatar>
 
           <div class="flex flex-col">
             <!-- Name -->
@@ -401,6 +396,16 @@ class Widget extends LitElement {
   _toggleIdentities(showIdentities = true) {
     this.showAllIdentities = showIdentities;
     this.requestUpdate();
+  }
+
+  _getMemberInitials() {
+    if (!this.member.name && !this.member.slug) { return null }
+
+    if (this.member.name && this.member.name.split(' ').length > 1) {
+      return `${this.member.name.split(' ')[0][0]}${this.member.name.split(' ')[1][0]}`.toUpperCase()
+    } else {
+      return this.member.slug.slice(0, 2).toUpperCase()
+    }
   }
 
   /**

--- a/src/components/widget.test.js
+++ b/src/components/widget.test.js
@@ -144,7 +144,7 @@ describe("obe-widget", () => {
     global.chrome = originalChrome;
   });
 
-  describe("'_toggleTags", () => {
+  describe("#_toggleTags", () => {
     it("sets showAllTags to true by default", () => {
       expect(element.showAllTags).toBe(false);
       element._toggleTags();
@@ -272,6 +272,32 @@ describe("obe-widget", () => {
       expect(dropdown.querySelectorAll("obe-identity").length).toEqual(6);
       expect(dropdown.innerHTML).not.toMatch(/\+.*1 more/);
       expect(dropdown.innerHTML).toMatch("Show fewer");
+    });
+  });
+
+  describe("#_getMemberInitials", () => {
+    it("uses the name initials if it exists and has a space", () => {
+      element.member = {
+        name: "Sally Ride",
+        slug: "sally-ride",
+      };
+      expect(element._getMemberInitials()).toBe('SR')
+    });
+
+    it("uses the slug first two letters if name does not have a space", () => {
+      element.member = {
+        name: "Nospace",
+        slug: "sally-ride",
+      };
+      expect(element._getMemberInitials()).toBe('SA')
+    });
+
+    it("uses the slug first two letters if name does not exist", () => {
+      element.member = {
+        name: null,
+        slug: "sally-ride",
+      };
+      expect(element._getMemberInitials()).toBe('SA')
     });
   });
 


### PR DESCRIPTION
This PR fixes two cases where data is missing.

**Organization website does not exist**

This can happen with custom organizations. It used to break the widget altogether, and now displays the organization name without a link.

**Avatar URL does not exists, or leads to a 404**

This now shows a “fallback” avatar displaying the members’ initials:

![CleanShot 2023-06-05 at 13 52 34@2x](https://github.com/orbit-love/orbit-browser-extension/assets/2587348/829d6ccb-0910-461d-a395-a6c7f7d1c8f5)
(avatar URL does not exist)

![CleanShot 2023-06-05 at 13 52 54@2x](https://github.com/orbit-love/orbit-browser-extension/assets/2587348/00c6789e-351b-4f4d-a03b-091337c100ba)
(Avatar URL results in a 404)