### PR TITLE
[FIX] UI fixes for options page

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -25,7 +25,7 @@
     <div class="mx-auto max-w-3xl lg:mt-10">
       <div x-data="orbit">
         <!-- Status messages. Wrapped with fixed height element to prevent content from jumping when they appear -->
-        <div class="h-10">
+        <div class="min-h-[44px]">
           <figure x-show="!!errorMessage" x-cloak role="alert"
             class="flex gap-x-2 items-center pt-5 text-base font-semibold text-red-700">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"


### PR DESCRIPTION
Used min height instead of fixed height for flash wrapper, which resolved both:
- [x] If API token, auth error messages do not show
- [x] API token + success overflows

<img width="1324" alt="CleanShot 2023-06-07 at 15 26 38@2x" src="https://github.com/orbit-love/orbit-browser-extension/assets/45462299/f3402643-aa19-4d79-b2da-a75a1065c0ef">

<img width="1255" alt="CleanShot 2023-06-07 at 15 27 27@2x" src="https://github.com/orbit-love/orbit-browser-extension/assets/45462299/cc568560-be61-480c-990f-a3bb25e7d09a">

